### PR TITLE
update on the snews tier publisher

### DIFF
--- a/SNEWS_PT/__main__.py
+++ b/SNEWS_PT/__main__.py
@@ -13,7 +13,7 @@ from .snews_pub import Publisher
 from .snews_sub import Subscriber
 from .message_schema import Message_Schema as msg_schema
 import click
-import os
+import os, sys
 
 @click.group(invoke_without_command=True)
 @click.version_option(__version__)
@@ -37,7 +37,7 @@ def main(ctx, env):
 @click.argument('file', nargs=-1)
 @click.pass_context
 def publish(ctx, file, verbose):
-    """ Publish a message using snews_pub
+    """ Publish a message using snews_pub, multiple files are allowed
     Examples
     --------
     $: snews_pt publish my_json_message.json
@@ -48,12 +48,16 @@ def publish(ctx, file, verbose):
     If no file is given it can still submit dummy messages with default values
     """
     click.clear()
-    data = snews_pt_utils._parse_file(file)
-    messages, names_list = snews_pt_utils._tier_decider(data)
-    for name, message in zip(names_list, messages):
-        click.secho(f'\nPublishing to {name}; ', bold=True, fg='bright_cyan')
+    for f in file:
+        if f.endswith('.json'):
+            data = snews_pt_utils._parse_file(f)
+        else:
+            click.secho(f"Expected json file with .json format! Got {f}", fg='red', bold=True)
+            sys.exit()
+
+        messages, names_list = snews_pt_utils._tier_decider(data)
         pub = ctx.with_resource(Publisher(ctx.obj['env'], verbose=verbose))
-        pub.send(message)
+        pub.send(messages)
 
 
 @main.command()

--- a/SNEWS_PT/__main__.py
+++ b/SNEWS_PT/__main__.py
@@ -9,13 +9,11 @@
 
 from . import __version__
 from . import snews_pt_utils
-from .snews_pub import Publisher, Heartbeat, Retraction
+from .snews_pub import Publisher
 from .snews_sub import Subscriber
 from .message_schema import Message_Schema as msg_schema
 import click
 import os
-import inspect
-
 
 @click.group(invoke_without_command=True)
 @click.version_option(__version__)
@@ -34,44 +32,6 @@ def main(ctx, env):
     ctx.obj['env'] = env
     ctx.obj['DETECTOR_NAME'] = os.getenv("DETECTOR_NAME")
 
-# @main.command()
-# @click.argument('tiers', nargs=-1)
-# @click.option('--verbose','-v', type=bool, default=True)
-# @click.option('--file','-f', type=str, default="", show_default='data file')
-# @click.pass_context
-# def publish(ctx, tiers, file, verbose):
-#     """ Publish a message using snews_pub
-#
-#     Notes
-#     -----
-#     The topics are read from the defaults i.e. from auxiliary/test-config.env
-#     If no file is given it can still submit dummy messages with default values
-#     """
-#     click.clear()
-#     tier_data_pairs = {'CoincidenceTier':snews_pt_utils.coincidence_tier_data(),
-#                        'SigTier':snews_pt_utils.sig_tier_data(),
-#                        'TimeTier':snews_pt_utils.time_tier_data(),
-#                        'FalseOBS':snews_pt_utils.retraction_data(),
-#                        'Heartbeat':snews_pt_utils.heartbeat_data()}
-#
-#     tiers_list, names_list = snews_pt_utils._check_cli_request(tiers)
-#     for Tier, name in zip(tiers_list, names_list):
-#         click.secho(f'\nPublishing to {name}; ', bold=True, fg='bright_cyan')
-#         # look for the data
-#         if file != "":
-#             data = snews_pt_utils._parse_file(file)
-#         else:
-#             # get default data for tier
-#             data = tier_data_pairs[name]
-#         if 'detector_name' in data.keys():
-#             detector = data['detector_name']
-#         else:
-#             detector = ctx.obj['DETECTOR_NAME']
-#         data['detector_name'] = detector
-#         message = Tier(**data).message()
-#         pub = ctx.with_resource(Publisher(ctx.obj['env'], verbose=verbose))
-#         pub.send(message)
-
 @main.command()
 @click.option('--verbose','-v', type=bool, default=True)
 @click.argument('file', nargs=-1)
@@ -89,7 +49,7 @@ def publish(ctx, file, verbose):
     """
     click.clear()
     data = snews_pt_utils._parse_file(file)
-    names_list, messages = snews_pt_utils._tier_decider(data)
+    messages, names_list = snews_pt_utils._tier_decider(data)
     for name, message in zip(names_list, messages):
         click.secho(f'\nPublishing to {name}; ', bold=True, fg='bright_cyan')
         pub = ctx.with_resource(Publisher(ctx.obj['env'], verbose=verbose))
@@ -129,6 +89,7 @@ def heartbeat(ctx, status, machine_time, verbose):
     pub.send(message)
 
 
+# TODO: add retraction
 # @main.command()
 # @click.option('--tier','-t', nargs=1, help='Name of tier you want to retract from')
 # @click.option('--number','-n', type=int, default=1, help='Number of most recent message you want to retract')

--- a/SNEWS_PT/__main__.py
+++ b/SNEWS_PT/__main__.py
@@ -149,5 +149,13 @@ def message_schema(tier):
                 click.secho(f'{k:<20s}:(User Input)', fg='bright_cyan')
         click.echo()
 
+@main.command()
+def run_scenarios():
+    """
+    """
+    base = os.path.dirname(os.path.realpath(__file__))
+    path = os.path.join(base, 'test/test_scenarios.py')
+    os.system(f'python3 {path}')
+
 if __name__ == "__main__":
     main()

--- a/SNEWS_PT/message_schema.py
+++ b/SNEWS_PT/message_schema.py
@@ -1,4 +1,4 @@
-from .snews_pt_utils import TimeStuff, get_detector
+from .snews_pt_utils import get_detector, TimeStuff
 from ._version import version as __version__
 
 
@@ -18,7 +18,7 @@ class Message_Schema:
     """
 
     def __init__(self, env_path=None, detector_key='TEST', is_pre_sn=False):
-        self.times = TimeStuff(env_path)
+        self.times = TimeStuff(env_path) # never used actually
         self.detector = get_detector(detector_key)
         self.detector_name = self.detector.name
         self.is_pre_sn = is_pre_sn
@@ -94,7 +94,7 @@ class Message_Schema:
 
         if tier == 'CoincidenceTier':
             message['neutrino_time'] = data['neutrino_time']
-            message['p_value'] = data['p_value']
+            message['p_val'] = data['p_val']
             message['meta'] = data['meta']
 
         if tier == 'Retraction':

--- a/SNEWS_PT/snews_pt_utils.py
+++ b/SNEWS_PT/snews_pt_utils.py
@@ -266,7 +266,7 @@ def heartbeat_data(machine_time=None, detector_status=None, meta=None):
     return heartbeat_dict
 
 
-def _tier_decider(data:dict) -> tuple:
+def _tier_decider(data:dict, env_file=None) -> tuple:
     """ Decide on the tier(s) or commands (Heartbeat/Retraction)
         Based on the content of the message
 
@@ -274,6 +274,10 @@ def _tier_decider(data:dict) -> tuple:
     from inspect import signature
     from .message_schema import Message_Schema
 
+    # set environment and assign detector name & pre SN flag
+    set_env(env_file)
+    data["is_pre_sn"] = data.get("is_pre_sn", False)
+    data['detector_name'] = data.get("detector_name", os.getenv('DETECTOR_NAME'))
     schema = Message_Schema(detector_key=data['detector_name'] , is_pre_sn=data['is_pre_sn'] )
     valid_keys = ["detector_name", "machine_time", "nu_time", "p_val", "p_values", "timing_series", "which_tier",
                   "n_retract_latest", "retraction_reason", "detector_status", "is_pre_sn",]
@@ -297,7 +301,7 @@ def _tier_decider(data:dict) -> tuple:
     #     _append_messages(time_tier_data, 'TimingTier')
 
     # CoincidenceTier if it has nu time
-    if type(data.get('nu_time', False))==float:
+    if data.get('nu_time', False):
         _append_messages(coincidence_tier_data,'CoincidenceTier')
 
     # SignificanceTier if it has p_values

--- a/SNEWS_PT/snews_pt_utils.py
+++ b/SNEWS_PT/snews_pt_utils.py
@@ -323,7 +323,7 @@ def _tier_decider(data:dict, env_file=None) -> tuple:
     #     _append_messages(time_tier_data, 'TimingTier')
 
     # CoincidenceTier if it has nu time
-    if data.get('neutrino_time', False):
+    if type(data.get('neutrino_time', False)) == str:
         _append_messages(coincidence_tier_data,'CoincidenceTier')
 
     # SignificanceTier if it has p_values

--- a/SNEWS_PT/snews_pt_utils.py
+++ b/SNEWS_PT/snews_pt_utils.py
@@ -281,17 +281,13 @@ def _tier_decider(data:dict) -> tuple:
     # if there are keys that wouldn't belong to any tier/command pass them as meta
     meta_keys = [key for key,value in data.items() if sys.getsizeof(value) < 2048]
     meta_data = {k:data[k] for k in meta_keys if k not in valid_keys}
-    print('meta data ',meta_data)
     messages, tiernames = [], []
     def _append_messages(tier_function, name):
         tier_keys = list(signature(tier_function).parameters.keys())
         data_for_tier = {k: v for k, v in data.items() if k in tier_keys}
         data_for_tier = tier_function(**data_for_tier)
-        print(name)
         if name not in ['Retraction','Heartbeat']:
             data_for_tier['meta'] = meta_data
-            print(name, 'APPENDED META', meta_data)
-        # print(f">>>>> \n{data_for_tier}")
         msg =  schema.get_schema(tier=name, data=data_for_tier, )
         tiernames.append(name)
         messages.append(msg)

--- a/SNEWS_PT/snews_pub.py
+++ b/SNEWS_PT/snews_pub.py
@@ -61,7 +61,6 @@ class Publisher:
 
         """
         for message in messages:
-            print(message)
             self.stream.write(message)
             self.display_message(message)
 

--- a/SNEWS_PT/snews_pub.py
+++ b/SNEWS_PT/snews_pub.py
@@ -98,7 +98,6 @@ class SNEWSTiersPublisher:
         # if is_pre_sn not given, it is False. If name not given fetch from env
         self.args_dict["is_pre_sn"] = kwargs.get("is_pre_sn", False)
         self.args_dict['detector_name'] = kwargs.get("detector_name", os.getenv('DETECTOR_NAME'))
-        self.schema = Message_Schema(detector_key=self.args_dict['detector_name'], is_pre_sn=kwargs.get("is_pre_sn", False))
         self.messages, self.tiernames = snews_pt_utils._tier_decider(self.args_dict)
 
         # if we want to have all of them as attributes,
@@ -110,6 +109,9 @@ class SNEWSTiersPublisher:
 
         """
         input_json = snews_pt_utils._parse_file(jsonfile)
+        self.args_dict = input_json
+        self.args_dict["is_pre_sn"] = input_json.get("is_pre_sn", False)
+        self.args_dict['detector_name'] = input_json.get("detector_name", os.getenv('DETECTOR_NAME'))
         assert type(input_json)==dict ,'json is not read as dictionary'
         self.messages, self.tiernames = snews_pt_utils._tier_decider(input_json)
 

--- a/SNEWS_PT/snews_pub.py
+++ b/SNEWS_PT/snews_pub.py
@@ -92,16 +92,9 @@ class SNEWSTiersPublisher:
       `is_pre_sn`
     """
     def __init__(self, env_file=None, **kwargs):
-        snews_pt_utils.set_env(env_file)
         self.args_dict = dict(**kwargs)
-        # if is_pre_sn not given, it is False. If name not given fetch from env
-        self.args_dict["is_pre_sn"] = kwargs.get("is_pre_sn", False)
-        self.args_dict['detector_name'] = kwargs.get("detector_name", os.getenv('DETECTOR_NAME'))
-        self.messages, self.tiernames = snews_pt_utils._tier_decider(self.args_dict)
-
-        # if we want to have all of them as attributes,
-        # for key, value in kwargs.items():
-        #     setattr(self, key, value)
+        self.env_file = env_file
+        self.messages, self.tiernames = snews_pt_utils._tier_decider(self.args_dict, env_file)
 
     def from_json(self, jsonfile):
         """ Read the data from a json file
@@ -109,10 +102,7 @@ class SNEWSTiersPublisher:
         """
         input_json = snews_pt_utils._parse_file(jsonfile)
         self.args_dict = input_json
-        self.args_dict["is_pre_sn"] = input_json.get("is_pre_sn", False)
-        self.args_dict['detector_name'] = input_json.get("detector_name", os.getenv('DETECTOR_NAME'))
-        assert type(input_json)==dict ,'json is not read as dictionary'
-        self.messages, self.tiernames = snews_pt_utils._tier_decider(input_json)
+        self.messages, self.tiernames = snews_pt_utils._tier_decider(input_json, self.env_file)
 
     def send_to_snews(self):
         with Publisher() as pub:

--- a/SNEWS_PT/snews_pub.py
+++ b/SNEWS_PT/snews_pub.py
@@ -96,13 +96,13 @@ class SNEWSTiersPublisher:
         self.env_file = env_file
         self.messages, self.tiernames = snews_pt_utils._tier_decider(self.args_dict, env_file)
 
-    def from_json(self, jsonfile):
+    @classmethod
+    def from_json(cls, jsonfile, env_file=None):
         """ Read the data from a json file
 
         """
         input_json = snews_pt_utils._parse_file(jsonfile)
-        self.args_dict = input_json
-        self.messages, self.tiernames = snews_pt_utils._tier_decider(input_json, self.env_file)
+        return cls(env_file=env_file, **input_json)
 
     def send_to_snews(self):
         with Publisher() as pub:

--- a/SNEWS_PT/snews_pub.py
+++ b/SNEWS_PT/snews_pub.py
@@ -61,6 +61,7 @@ class Publisher:
 
         """
         for message in messages:
+            print(message)
             self.stream.write(message)
             self.display_message(message)
 
@@ -76,91 +77,42 @@ class Publisher:
 
 
 class SNEWSTiersPublisher:
-    def __init__(self, detector_name=None, machine_time=None, nu_time=None, p_value=None,
-                 p_values=None, timing_series=None, which_tier=None,
-                 n_retract_latest=0, retraction_reason=None, detector_status=None, is_pre_sn=False, **kwargs):
-        self.machine_time = machine_time
-        self.nu_time = nu_time
-        self.p_value = p_value
-        self.p_values = p_values
-        self.timing_series = timing_series
-        self.which_tier = which_tier
-        self.n_retract_latest = n_retract_latest
-        self.retraction_reason = retraction_reason
-        self.detector_status = detector_status
-        self.is_pre_sn = is_pre_sn
-        self.detector_name = detector_name
-        if detector_name is None:
-            self.detector_name = os.getenv('DETECTOR_NAME')
-        self.kwargs = dict(kwargs)
-        self.schema = Message_Schema(detector_key=self.detector_name, is_pre_sn=is_pre_sn)
+    """
+    To use a json file call SNEWSTiersPublisher().from_json(<filename>)
+    Else, the following keys and more kwargs can be passed
+      `detector_name`
+      `machine_time`
+      `nu_time`
+      `p_val`
+      `p_values`
+      `timing_series`
+      `which_tier`
+      `n_retract_latest`
+      `retraction_reason`
+      `detector_status`
+      `is_pre_sn`
+    """
+    def __init__(self, env_file=None, **kwargs):
+        snews_pt_utils.set_env(env_file)
+        self.args_dict = dict(**kwargs)
+        # if is_pre_sn not given, it is False. If name not given fetch from env
+        self.args_dict["is_pre_sn"] = kwargs.get("is_pre_sn", False)
+        self.args_dict['detector_name'] = kwargs.get("detector_name", os.getenv('DETECTOR_NAME'))
+        self.schema = Message_Schema(detector_key=self.args_dict['detector_name'], is_pre_sn=kwargs.get("is_pre_sn", False))
+        self.messages, self.tiernames = snews_pt_utils._tier_decider(self.args_dict)
 
-    def _make_tier_messages(self, ):
-        messages = []
-        meta = {k: v for k, v in self.kwargs.items() if sys.getsizeof(v) < 2048}
-        if len(meta):
-            click.echo(
-                click.style('\t"' + '; '.join(meta.keys()) + '"', fg='magenta', bold=True) + ' are passed as meta data')
+        # if we want to have all of them as attributes,
+        # for key, value in kwargs.items():
+        #     setattr(self, key, value)
 
-        if self.is_pre_sn and type(self.timing_series) == list:
-            data = snews_pt_utils.time_tier_data(machine_time=self.machine_time,
-                                                 nu_time=self.nu_time,
-                                                 timing_series=self.timing_series,
-                                                 p_val=self.p_value,
-                                                 meta=meta
-                                                 )
+    def from_json(self, jsonfile):
+        """ Read the data from a json file
 
-            time_message = self.schema.get_schema(tier='TimeTier', data=data, )
-            messages.append(time_message)
-            return messages
-        # TODO: 16/02 ask about p val in CT
-        # CoincidenceTier if it has p_value and nu time
-        if type(self.p_value) == float and type(self.nu_time) == str:
-            data = snews_pt_utils.coincidence_tier_data(machine_time=self.machine_time, p_val=self.p_value,
-                                                        nu_time=self.nu_time, meta=meta)
-            coincidence_message = self.schema.get_schema(tier='CoincidenceTier', data=data, )
-            messages.append(coincidence_message)
-
-        # SignificanceTier if it has p_values
-        if type(self.p_values) == list:
-            data = snews_pt_utils.sig_tier_data(machine_time=self.machine_time,
-                                                nu_time=self.nu_time,
-                                                p_values=self.p_values,
-                                                meta=meta,
-                                                )
-            sig_message = self.schema.get_schema(tier='SigTier', data=data, )
-            messages.append(sig_message)
-
-        # TimingTier if timing_series exists (@Seb why do we need p_value to be float?)
-        if type(self.timing_series) == list and type(self.p_value) == float:
-            data = snews_pt_utils.time_tier_data(machine_time=self.machine_time,
-                                                 nu_time=self.nu_time,
-                                                 timing_series=self.timing_series,
-                                                 p_val=self.p_value,
-                                                 meta=meta
-                                                 )
-
-            time_message = self.schema.get_schema(tier='TimeTier', data=data, )
-            messages.append(time_message)
-
-        # Retraction Command if retraction field is passed
-        if self.n_retract_latest != 0 and type(self.which_tier) == str:
-            data = snews_pt_utils.retraction_data(machine_time=self.machine_time,
-                                                  which_tier=self.which_tier, n_retract_latest=self.n_retract_latest,
-                                                  retraction_reason=self.retraction_reason, meta=meta)
-            retraction_message = self.schema.get_schema(tier='Retraction', data=data, )
-            messages.append(retraction_message)
-
-        # Heartbeat if detector status passed (and maybe other==None ?)
-        # they can also set status=ON when they submit coincidence, do we want to publish also a HB at the same time?
-        if type(self.detector_status) == str and type(self.machine_time) == str:
-            data = snews_pt_utils.heartbeat_data(detector_status=self.detector_status, machine_time=self.machine_time)
-            heartbeat_message = self.schema.get_schema(tier='Heartbeat', data=data, )
-            messages.append(heartbeat_message)
-
-        return messages
+        """
+        input_json = snews_pt_utils._parse_file(jsonfile)
+        assert type(input_json)==dict ,'json is not read as dictionary'
+        self.messages, self.tiernames = snews_pt_utils._tier_decider(input_json)
 
     def send_to_snews(self):
-        messages = self._make_tier_messages()
         with Publisher() as pub:
-            pub.send(messages)
+            pub.send(self.messages)

--- a/SNEWS_PT/snews_pub.py
+++ b/SNEWS_PT/snews_pub.py
@@ -60,6 +60,8 @@ class Publisher:
             list containing observation message.
 
         """
+        if type(messages)==dict:
+            messages = list(messages)
         for message in messages:
             self.stream.write(message)
             self.display_message(message)
@@ -81,7 +83,7 @@ class SNEWSTiersPublisher:
     Else, the following keys and more kwargs can be passed
       `detector_name`
       `machine_time`
-      `nu_time`
+      `neutrino_time`
       `p_val`
       `p_values`
       `timing_series`
@@ -97,12 +99,14 @@ class SNEWSTiersPublisher:
         self.messages, self.tiernames = snews_pt_utils._tier_decider(self.args_dict, env_file)
 
     @classmethod
-    def from_json(cls, jsonfile, env_file=None):
+    def from_json(cls, jsonfile, env_file=None, **kwargs):
         """ Read the data from a json file
+            Additional data / overwrite is allowed
 
         """
         input_json = snews_pt_utils._parse_file(jsonfile)
-        return cls(env_file=env_file, **input_json)
+        output_data = {**input_json, **kwargs}
+        return cls(env_file=env_file, **output_data)
 
     def send_to_snews(self):
         with Publisher() as pub:

--- a/SNEWS_PT/test/make_scenarios.py
+++ b/SNEWS_PT/test/make_scenarios.py
@@ -2,35 +2,65 @@ import json
 
 msg1 = {"detector_name": "XENONnT",
         "neutrino_time": "22/01/01 12:34:45:678999",
-        "p_value": 0.98}
+        "p_val": 0.98}
 
 msg2 = {"detector_name": "DS-20K",
         "neutrino_time": "22/01/01 12:34:47:678999",
-        "p_value": 0.98}
+        "p_val": 0.98}
 
 msg3 = {"detector_name": "DUNE",
         "neutrino_time": "22/01/01 12:34:55:678999",
-        "p_value": 0.98}
+        "p_val": 0.98}
 
 msg4 = {"detector_name": "JUNO",
         "neutrino_time": "22/01/01 12:30:55:678999",
-        "p_value": 0.98}
+        "p_val": 0.98}
 
 msg5 = {"detector_name": "Baksan",
         "neutrino_time": "22/01/01 12:30:52:678999",
-        "p_value": 0.98}
+        "p_val": 0.98}
 
 msg6 = {"detector_name": "JUNO",
         "neutrino_time": "22/01/01 12:30:56:678999",
-        "p_value": 0.98}
+        "p_val": 0.98}
+
+####
+msg7 = {"detector_name": "Borexino",
+        "neutrino_time": "22/01/01 12:30:10:678999",
+        "p_val": 0.98}
+
+msg8 = {"detector_name": "ICE",
+        "neutrino_time": "22/01/01 12:30:19:678999",
+        "p_val": 0.98}
+
+msg9 = {"detector_name": "NOvA",
+        "neutrino_time": "22/01/01 12:30:21:678999",
+        "p_val": 0.98}
+
+msg10 = {"detector_name": "DS-20K",
+        "neutrino_time": "22/01/01 12:30:22:678999",
+        "p_val": 0.98}
+
+msg11 = {"detector_name": "HALO",
+        "neutrino_time": "22/01/01 12:30:20:678999",
+        "p_val": 0.98}
+
+msg12 = {"detector_name": "XENONnT",
+        "neutrino_time": "22/01/01 12:30:29:678999",
+        "p_val": 0.98}
+
+msg13 = {"detector_name": "JUNO",
+        "neutrino_time": "22/01/01 12:30:18:678999",
+        "p_val": 0.98}
 
 scenarios = {
     "simple coincidence": [msg1,msg2],
     "exact 10s coincidence": [msg1, msg3],
     "two coincidences":[msg1,msg2, msg4, msg5],
-    "same detector submits twice":[msg1, msg1],
-    "same detector submits sequentially":[msg4, msg6],
-    "times are out of order":[msg3, msg2, msg1]
+    "same message submitted twice":[msg1, msg1],
+    "same detector submits within 1sec":[msg4, msg6],
+    "3 coincident message, out of order":[msg3, msg2, msg1],
+    "msgs at 10, 19, 21, 22, 20, 29, 18 seconds": [msg7,msg8,msg9,msg10,msg11,msg12,msg13],
 }
 
 with open("scenarios.json", "w") as write_file:

--- a/SNEWS_PT/test/scenarios.json
+++ b/SNEWS_PT/test/scenarios.json
@@ -3,87 +3,124 @@
     {
       "detector_name": "XENONnT",
       "neutrino_time": "22/01/01 12:34:45:678999",
-      "p_value": 0.98
+      "p_val": 0.98
     },
     {
       "detector_name": "DS-20K",
       "neutrino_time": "22/01/01 12:34:47:678999",
-      "p_value": 0.98
+      "p_val": 0.98
     }
   ],
   "exact 10s coincidence": [
     {
       "detector_name": "XENONnT",
       "neutrino_time": "22/01/01 12:34:45:678999",
-      "p_value": 0.98
+      "p_val": 0.98
     },
     {
       "detector_name": "DUNE",
       "neutrino_time": "22/01/01 12:34:55:678999",
-      "p_value": 0.98
+      "p_val": 0.98
     }
   ],
   "two coincidences": [
     {
       "detector_name": "XENONnT",
       "neutrino_time": "22/01/01 12:34:45:678999",
-      "p_value": 0.98
+      "p_val": 0.98
     },
     {
       "detector_name": "DS-20K",
       "neutrino_time": "22/01/01 12:34:47:678999",
-      "p_value": 0.98
+      "p_val": 0.98
     },
     {
       "detector_name": "JUNO",
       "neutrino_time": "22/01/01 12:30:55:678999",
-      "p_value": 0.98
+      "p_val": 0.98
     },
     {
       "detector_name": "Baksan",
       "neutrino_time": "22/01/01 12:30:52:678999",
-      "p_value": 0.98
+      "p_val": 0.98
     }
   ],
-  "same detector submits twice": [
+  "same message submitted twice": [
     {
       "detector_name": "XENONnT",
       "neutrino_time": "22/01/01 12:34:45:678999",
-      "p_value": 0.98
+      "p_val": 0.98
     },
     {
       "detector_name": "XENONnT",
       "neutrino_time": "22/01/01 12:34:45:678999",
-      "p_value": 0.98
+      "p_val": 0.98
     }
   ],
-  "same detector submits sequentially": [
+  "same detector submits within 1sec": [
     {
       "detector_name": "JUNO",
       "neutrino_time": "22/01/01 12:30:55:678999",
-      "p_value": 0.98
+      "p_val": 0.98
     },
     {
       "detector_name": "JUNO",
       "neutrino_time": "22/01/01 12:30:56:678999",
-      "p_value": 0.98
+      "p_val": 0.98
     }
   ],
-  "times are out of order": [
+  "3 coincident message, out of order": [
     {
       "detector_name": "DUNE",
       "neutrino_time": "22/01/01 12:34:55:678999",
-      "p_value": 0.98
+      "p_val": 0.98
     },
     {
       "detector_name": "DS-20K",
       "neutrino_time": "22/01/01 12:34:47:678999",
-      "p_value": 0.98
+      "p_val": 0.98
     },
     {
       "detector_name": "XENONnT",
       "neutrino_time": "22/01/01 12:34:45:678999",
-      "p_value": 0.98
+      "p_val": 0.98
+    }
+  ],
+  "msgs at 10, 19, 21, 22, 20, 29, 18 seconds": [
+    {
+      "detector_name": "Borexino",
+      "neutrino_time": "22/01/01 12:30:10:678999",
+      "p_val": 0.98
+    },
+    {
+      "detector_name": "ICE",
+      "neutrino_time": "22/01/01 12:30:19:678999",
+      "p_val": 0.98
+    },
+    {
+      "detector_name": "NOvA",
+      "neutrino_time": "22/01/01 12:30:21:678999",
+      "p_val": 0.98
+    },
+    {
+      "detector_name": "DS-20K",
+      "neutrino_time": "22/01/01 12:30:22:678999",
+      "p_val": 0.98
+    },
+    {
+      "detector_name": "HALO",
+      "neutrino_time": "22/01/01 12:30:20:678999",
+      "p_val": 0.98
+    },
+    {
+      "detector_name": "XENONnT",
+      "neutrino_time": "22/01/01 12:30:29:678999",
+      "p_val": 0.98
+    },
+    {
+      "detector_name": "JUNO",
+      "neutrino_time": "22/01/01 12:30:18:678999",
+      "p_val": 0.98
     }
   ]
 }

--- a/SNEWS_PT/test/test_combined_message.json
+++ b/SNEWS_PT/test/test_combined_message.json
@@ -3,7 +3,7 @@
         "test machine time",
     "neutrino_time": 
         "test nu time",
-    "p_value":
+    "p_val":
         "test p-value",
     "p_values":
         "test p-values",

--- a/SNEWS_PT/test/test_scenarios.py
+++ b/SNEWS_PT/test/test_scenarios.py
@@ -6,33 +6,34 @@ from SNEWS_PT.snews_pub import SNEWSTiersPublisher, Publisher
 with open(osp.join(osp.dirname(__file__), "scenarios.json")) as json_file:
     data = json.load(json_file)
 
-try:
-    import inquirer
-    from inquirer.themes import GreenPassion
-    questions = [
-      inquirer.Checkbox('scenarios',
-                    message=click.style(" Which scenario(s) would you like to run next?", bg='yellow', bold=True),
-                    choices=list(data.keys()),
-                )
-    ]
+# try:
+import inquirer
+from inquirer.themes import GreenPassion
+questions = [
+  inquirer.Checkbox('scenarios',
+                message=click.style(" Which scenario(s) would you like to run next?", bg='yellow', bold=True),
+                choices=list(data.keys()),
+            )
+]
 
-    while True:
-        try:
-            answers = inquirer.prompt(questions) # , theme=GreenPassion()
-            for scenario in answers['scenarios']:
-                click.secho(f"\n>>> Testing {scenario}", fg='yellow', bold=True)
-                messages = data[scenario]
-                for msg in messages: # send one by one and sleep in between
-                    SNEWSTiersPublisher(**msg).send_to_snews()
-                    time.sleep(1)
-                    # clear cache after each scenario
-                    time.sleep(1)
-                    pub.send([{'_id': 'hard-reset_'}])
-                    print('> Cache cleaned\n')
+while True:
+    try:
+        answers = inquirer.prompt(questions) # , theme=GreenPassion()
+        for scenario in answers['scenarios']:
+            click.secho(f"\n>>> Testing {scenario}", fg='yellow', bold=True)
+            messages = data[scenario]
+            for msg in messages: # send one by one and sleep in between
+                SNEWSTiersPublisher(**msg).send_to_snews()
+                time.sleep(1)
+                # clear cache after each scenario
+            with Publisher() as pub:
+                pub.send([{'_id': 'hard-reset_'}])
+                print('> Cache cleaned\n')
 
-        except KeyboardInterrupt:
-            sys.exit()
-except:
+    except KeyboardInterrupt:
+        sys.exit()
+# except:
+#     print('Something went wrong')
     # with Publisher() as pub:
     #     for i, (scenario, dicts) in enumerate(data.items()):
     #         input('Hit enter to run next scenario')


### PR DESCRIPTION
- It allows for environment setting (this is needed if the user doesn't pass detector name, it tries to fetch from env)
- can read from json file (simple `from_json()` method, parses and passes this data)
- arbitrary number of key-value pairs; `init` takes `env_file=None, **kwargs` and anything can be passed, it is looked in the `snews_pt_utils._tier_decider` and both the messages and which tiers found is returned
- it keeps the messages and tiers as attributes; the `messages` and `tiernames` (see above) are appended as attribute thus;

```
from SNEWS_PT.snews_pub import SNEWSTiersPublisher
snews = SNEWSTiersPublisher(detector_name='KamLAND', timing_series=['4:31:05:565', '4:31:05:575', '4:31:05:585'],
                                                  p_val=0.000007, p_values=[0.000007, 0.000004], machine_time='22/02/08 4:31:08:565')
```
can be further investigated before submitting a message i.e.
```
print(snews.messages)
print(snews.tiernames)
```
and finally `snews.send_to_snews()` submits the message.


Alternatively;
```
from SNEWS_PT.snews_pub import SNEWSTiersPublisher
snews = SNEWSTiersPublisher().from_json('myjsonfile.json')
snews.send_to_snews()
```