### PR TITLE
Sent Time Corrections

### DIFF
--- a/SNEWS_PT/__main__.py
+++ b/SNEWS_PT/__main__.py
@@ -33,17 +33,16 @@ def main(ctx, env):
 
 
 @main.command()
-@click.option('--firedrill/--no-firedrill', default=True)
+@click.option('--firedrill/--no-firedrill', default=True, show_default='True', help='Whether to use firedrill brokers or default ones')
 @click.argument('file', nargs=-1)
 @click.pass_context
 def publish(ctx, file, firedrill):
     """ Publish a message using snews_pub, multiple files are allowed
-    Examples
-    --------
+
     $: snews_pt publish my_json_message.json
 
     Notes
-    -----
+
     The topics are read from the defaults i.e. from auxiliary/test-config.env
     If no file is given it can still submit dummy messages with default values
     """
@@ -64,7 +63,7 @@ def publish(ctx, file, firedrill):
 
 @main.command()
 @click.option('--plugin', '-p', type=str, default="None")
-@click.option('--firedrill/--no-firedrill', default=True)
+@click.option('--firedrill/--no-firedrill', default=True, show_default='True', help='Whether to use firedrill brokers or default ones')
 @click.pass_context
 def subscribe(ctx, plugin, firedrill):
     """ Subscribe to Alert topic
@@ -131,12 +130,13 @@ def message_schema(ctx, requested_tier):
         
 
 @main.command()
-def run_scenarios():
+@click.option('--firedrill/--no-firedrill', default=True, show_default='True', help='Whether to use firedrill brokers or default ones')
+def run_scenarios(firedrill):
     """
     """
     base = os.path.dirname(os.path.realpath(__file__))
     path = os.path.join(base, 'auxiliary/try_scenarios.py')
-    os.system(f'python3 {path}')
+    os.system(f'python3 {path} {firedrill}')
 
 if __name__ == "__main__":
     main()

--- a/SNEWS_PT/auxiliary/try_scenarios.py
+++ b/SNEWS_PT/auxiliary/try_scenarios.py
@@ -28,7 +28,7 @@ try:
                     time.sleep(1)
                     # clear cache after each scenario
                 with Publisher() as pub:
-                    pub.send([{'_id': 'hard-reset_'}])
+                    pub.send([{'_id': 'hard-reset_', 'pass':'very1secret2password', 'detector_name':'TEST'}])
                     print('> Cache cleaned\n')
 
         except KeyboardInterrupt:

--- a/SNEWS_PT/auxiliary/try_scenarios.py
+++ b/SNEWS_PT/auxiliary/try_scenarios.py
@@ -7,32 +7,32 @@ fd_mode = bool(sys.argv[1])
 with open(osp.join(osp.dirname(__file__), "scenarios.json")) as json_file:
     data = json.load(json_file)
 
-try:
-    import inquirer
-    from inquirer.themes import GreenPassion
-    questions = [
-    inquirer.Checkbox('scenarios',
-                    message=click.style(" Which scenario(s) would you like to run next?", bg='yellow', bold=True),
-                    choices=list(data.keys()),
-                )
-    ]
+# try:
+import inquirer
+from inquirer.themes import GreenPassion
+questions = [
+inquirer.Checkbox('scenarios',
+                message=click.style(" Which scenario(s) would you like to run next?", bg='yellow', bold=True),
+                choices=list(data.keys()),
+            )
+]
 
-    while True:
-        try:
-            answers = inquirer.prompt(questions) # , theme=GreenPassion()
-            for scenario in answers['scenarios']:
-                click.secho(f"\n>>> Testing {scenario}", fg='yellow', bold=True)
-                messages = data[scenario]
-                for msg in messages: # send one by one and sleep in between
-                    SNEWSTiersPublisher(**msg, firedrill_mode=fd_mode).send_to_snews()
-                    time.sleep(1)
-                    # clear cache after each scenario
-                with Publisher() as pub:
-                    pub.send([{'_id': 'hard-reset_'}])
-                    print('> Cache cleaned\n')
+while True:
+    try:
+        answers = inquirer.prompt(questions) # , theme=GreenPassion()
+        for scenario in answers['scenarios']:
+            click.secho(f"\n>>> Testing {scenario}", fg='yellow', bold=True)
+            messages = data[scenario]
+            for msg in messages: # send one by one and sleep in between
+                SNEWSTiersPublisher(**msg, firedrill_mode=fd_mode).send_to_snews()
+                time.sleep(1)
+                # clear cache after each scenario
+            with Publisher() as pub:
+                pub.send([{'_id': 'hard-reset_'}])
+                print('> Cache cleaned\n')
 
-        except KeyboardInterrupt:
-            sys.exit()
-except Exception as e:
-    print("Something went wrong\n", e, "Try manually submitting messages :/")
-    
+    except KeyboardInterrupt:
+        sys.exit()
+# except Exception as e:
+#     print("Something went wrong\n", e, "\nTry manually submitting messages :/")
+#

--- a/SNEWS_PT/auxiliary/try_scenarios.py
+++ b/SNEWS_PT/auxiliary/try_scenarios.py
@@ -2,6 +2,7 @@
 import json, click, time, sys
 from os import path as osp
 from SNEWS_PT.snews_pub import SNEWSTiersPublisher, Publisher
+fd_mode = bool(sys.argv[1])
 
 with open(osp.join(osp.dirname(__file__), "scenarios.json")) as json_file:
     data = json.load(json_file)
@@ -23,7 +24,7 @@ try:
                 click.secho(f"\n>>> Testing {scenario}", fg='yellow', bold=True)
                 messages = data[scenario]
                 for msg in messages: # send one by one and sleep in between
-                    SNEWSTiersPublisher(**msg).send_to_snews()
+                    SNEWSTiersPublisher(**msg, firedrill_mode=fd_mode).send_to_snews()
                     time.sleep(1)
                     # clear cache after each scenario
                 with Publisher() as pub:

--- a/SNEWS_PT/auxiliary/try_scenarios.py
+++ b/SNEWS_PT/auxiliary/try_scenarios.py
@@ -7,32 +7,32 @@ fd_mode = bool(sys.argv[1])
 with open(osp.join(osp.dirname(__file__), "scenarios.json")) as json_file:
     data = json.load(json_file)
 
-# try:
-import inquirer
-from inquirer.themes import GreenPassion
-questions = [
-inquirer.Checkbox('scenarios',
-                message=click.style(" Which scenario(s) would you like to run next?", bg='yellow', bold=True),
-                choices=list(data.keys()),
-            )
-]
+try:
+    import inquirer
+    # from inquirer.themes import GreenPassion
+    questions = [
+    inquirer.Checkbox('scenarios',
+                    message=click.style(" Which scenario(s) would you like to run next?", bg='yellow', bold=True),
+                    choices=list(data.keys()),
+                )
+    ]
 
-while True:
-    try:
-        answers = inquirer.prompt(questions) # , theme=GreenPassion()
-        for scenario in answers['scenarios']:
-            click.secho(f"\n>>> Testing {scenario}", fg='yellow', bold=True)
-            messages = data[scenario]
-            for msg in messages: # send one by one and sleep in between
-                SNEWSTiersPublisher(**msg, firedrill_mode=fd_mode).send_to_snews()
-                time.sleep(1)
-                # clear cache after each scenario
-            with Publisher() as pub:
-                pub.send([{'_id': 'hard-reset_'}])
-                print('> Cache cleaned\n')
+    while True:
+        try:
+            answers = inquirer.prompt(questions) # , theme=GreenPassion()
+            for scenario in answers['scenarios']:
+                click.secho(f"\n>>> Testing {scenario}", fg='yellow', bold=True)
+                messages = data[scenario]
+                for msg in messages: # send one by one and sleep in between
+                    SNEWSTiersPublisher(**msg, firedrill_mode=fd_mode).send_to_snews()
+                    time.sleep(1)
+                    # clear cache after each scenario
+                with Publisher() as pub:
+                    pub.send([{'_id': 'hard-reset_'}])
+                    print('> Cache cleaned\n')
 
-    except KeyboardInterrupt:
-        sys.exit()
-# except Exception as e:
-#     print("Something went wrong\n", e, "\nTry manually submitting messages :/")
+        except KeyboardInterrupt:
+            sys.exit()
+except Exception as e:
+    print("Something went wrong\n", e, "\nTry manually submitting messages :/")
 #

--- a/SNEWS_PT/message_schema.py
+++ b/SNEWS_PT/message_schema.py
@@ -52,7 +52,7 @@ class Message_Schema:
         else:
             return f'{self.detector.id}_{tier}_{machine_time}'
 
-    def get_schema(self, tier, data, version=__version__):
+    def get_schema(self, tier, data, sent_time, version=__version__):
         """ Create a message schema for given topic type.
             Internally called in hop_pub
 
@@ -73,7 +73,7 @@ class Message_Schema:
                 message with the correct scheme 
 
         """
-        message = {"_id": self.id_format(tier=tier, machine_time=data['machine_time']),
+        message = {"_id": self.id_format(tier=tier, machine_time=sent_time), # data['machine_time']
                    "detector_name": self.detector_name,
                    "machine_time": data['machine_time'],
                    }
@@ -107,5 +107,5 @@ class Message_Schema:
                     message['_extra_' + key] = data[key]
 
         message["schema_version"] = version
-
+        message["sent_time"] = sent_time
         return message

--- a/SNEWS_PT/snews_pub.py
+++ b/SNEWS_PT/snews_pub.py
@@ -29,8 +29,8 @@ class Publisher:
             Option to display message when publishing.
         auth: `bool`
             Option to run hop-Stream without authentication. Pass False to do so
-        firedrill_mode :'bool'
-            use firedrill broker
+        firedrill_mode :`bool`
+            whether to use firedrill broker
         """
         snews_pt_utils.set_env(env_path)
         self.auth = auth
@@ -151,7 +151,8 @@ class SNEWSTiersPublisher:
         self.meta = dict(**kwargs)
         self.message_data['meta'] = self.meta
         self.env_file = env_file
-        self.messages, self.tiernames = snews_pt_utils._tier_decider(self.message_data, env_file)
+        stamp_time = snews_pt_utils.TimeStuff().get_utcnow()
+        self.messages, self.tiernames = snews_pt_utils._tier_decider(self.message_data, sent_time=stamp_time, env_file=env_file)
         self.firedrill_mode = firedrill_mode
     @classmethod
     def from_json(cls, jsonfile, env_file=None, **kwargs):

--- a/SNEWS_PT/snews_pub.py
+++ b/SNEWS_PT/snews_pub.py
@@ -66,7 +66,7 @@ class Publisher:
         if self.verbose:
             tier = message['_id'].split('_')[1]
             click.secho(f'{"-" * 64}', fg='bright_blue')
-            click.secho(f'Sending message to {tier}', fg='bright_red')
+            click.secho(f'Sending message to {tier} on {self.obs_broker}', fg='bright_red')
             if tier == 'Retraction':
                 click.secho("It's okay, we all make mistakes".upper(), fg='magenta')
             for k, v in message.items():

--- a/SNEWS_PT/test/test_coincidence_tier.py
+++ b/SNEWS_PT/test/test_coincidence_tier.py
@@ -10,8 +10,12 @@ def test_coincidence_expected():
     assert coin.message_data == {'detector_name': 'KamLAND', 'machine_time': None, 'neutrino_time': '12/06/09 15:31:08:1098', 
                                  'p_val': None, 'p_values': None, 'timing_series': None, 'which_tier': None, 'n_retract_latest': None, 
                                  'retraction_reason': None, 'detector_status': None, 'is_pre_sn': False, 't_bin_width': None, 'meta': {'p_value': 0.4}}
-    assert coin.messages == [{'_id': '4_CoincidenceTier_None', 'detector_name': 'KamLAND', 'machine_time': None, 'neutrino_time': '12/06/09 15:31:08:1098', 
-                              'p_val': None, 'meta': {'meta': {'p_value': 0.4}}, 'schema_version': '1.1.0'}]
+
+    input_messages = {'detector_name': 'KamLAND', 'machine_time': None, 'neutrino_time': '12/06/09 15:31:08:1098',
+                      'p_val': None, 'meta': {'meta': {'p_value': 0.4}}, 'schema_version': '1.1.0'}
+    for k,v in input_messages.items():
+        assert coin.messages[0][k] == v
+
     assert coin.env_file == None
     # Try to send message to SNEWS 2.0 server.
     try:

--- a/SNEWS_PT/test/test_significance_tier.py
+++ b/SNEWS_PT/test/test_significance_tier.py
@@ -28,17 +28,18 @@ def test_significance_expected():
                                  'meta': {'neutrino_times':
                                           ['12/06/09 15:31:08:1098',
                                            '12/06/09 15:33:07:8910']}}
-    assert sign.messages == [
-                            {'_id': '18_SigTier_None',
-                             'detector_name': 'DS-20K',
-                             'machine_time': None,
-                             'neutrino_time': None,
-                             't_bin_width': 0.8,
-                             'p_values': [0.4, 0.5],
-                             'meta': {'meta': {'neutrino_times':
-                                               ['12/06/09 15:31:08:1098',
-                                                '12/06/09 15:33:07:8910']}},
-                             'schema_version': '1.1.0'}]
+    input_message = {'detector_name': 'DS-20K',
+                     'machine_time': None,
+                     'neutrino_time': None,
+                     't_bin_width': 0.8,
+                     'p_values': [0.4, 0.5],
+                     'meta': {'meta': {'neutrino_times':
+                                       ['12/06/09 15:31:08:1098',
+                                        '12/06/09 15:33:07:8910']}},
+                     'schema_version': '1.1.0'}
+    for k,v in input_message.items():
+        assert sign.messages[0][k] == v
+
     assert sign.env_file is None
 
     # Try to send message to SNEWS 2.0 server.

--- a/SNEWS_PT/test/test_timing_tier.py
+++ b/SNEWS_PT/test/test_timing_tier.py
@@ -11,9 +11,14 @@ def test_timing_expected():
     assert tims.message_data == {'detector_name': 'XENONnT', 'machine_time': None, 'neutrino_time': '12/06/09 15:31:08:1098', 'p_val': None, 'p_values': None, 
                                  'timing_series': ['12/06/09 15:31:08:1098', '12/06/09 15:33:07:8910'], 'which_tier': None, 'n_retract_latest': None, 
                                  'retraction_reason': None, 'detector_status': None, 'is_pre_sn': False, 't_bin_width': None, 'meta': {}}
-    assert tims.messages == [{'_id': '19_CoincidenceTier_None', 'detector_name': 'XENONnT', 'machine_time': None, 'neutrino_time': '12/06/09 15:31:08:1098', 
-                              'p_val': None, 'meta': {'meta': {}}, 'schema_version': '1.1.0'}, {'_id': '19_TimeTier_None', 'detector_name': 'XENONnT', 'machine_time': None, 
-                              'neutrino_time': '12/06/09 15:31:08:1098', 'timing_series': ['12/06/09 15:31:08:1098', '12/06/09 15:33:07:8910'], 'meta': {'meta': {}}, 'schema_version': '1.1.0'}]
+
+    input_messages = [{'detector_name': 'XENONnT', 'machine_time': None, 'neutrino_time': '12/06/09 15:31:08:1098',
+                     'p_val': None, 'meta': {'meta': {}}, 'schema_version': '1.1.0'}, {'detector_name': 'XENONnT', 'machine_time': None,
+                     'neutrino_time': '12/06/09 15:31:08:1098', 'timing_series': ['12/06/09 15:31:08:1098', '12/06/09 15:33:07:8910'], 'meta': {'meta': {}}, 'schema_version': '1.1.0'}]
+    for i, message in enumerate(input_messages):
+        for k,v in message.items():
+            assert tims.messages[i][k] == v
+
     assert tims.env_file == None
     # Try to send message to SNEWS 2.0 server.
     try:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,14 +1,14 @@
-click~=8.0.4
+click~=8.1.2
 configparser==5.2.0
 docutils==0.17.1
 fixtures==3.0.0
-ipython==8.0.1
+ipython~=7.32.0
 myst-parser==0.16.1
 mock==4.0.3
 nose==1.3.7
 python-dotenv==0.19.2
 reno==3.5.0
-setuptools~=58.0.4
+setuptools~=62.1.0
 six==1.14.0
 Sphinx==4.2.0
 sphinx_rtd_theme==1.0.0
@@ -22,3 +22,4 @@ virtualenv==20.13.0
 wheel==0.34.2
 inquirer==2.9.1
 hop-client~=0.5.0
+attrs~=21.4.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,6 +6,7 @@ ipython~=7.32.0
 myst-parser==0.16.1
 mock==4.0.3
 nose==1.3.7
+pandas~=1.4.2
 python-dotenv==0.19.2
 reno==3.5.0
 setuptools~=62.1.0


### PR DESCRIPTION
What changed;
- CLI now also accepts `--firedrill/--no-firedrill` options and has docs see `snews_pt --help` (defaults True)
- `snews_pt run-scenarios` also has the firedrill option (default True)
- both subscriber and publisher also displays the broker once (to be sure if we are using firedrill brokers)
- When a message is published it creates a `utcnow` and appends to all messages `'sent_time'` field. 
- This `'sent_time'` is used to stamp the `'_id'` 


This `'sent_time'` is used to stamp the `'_id'` because it is always created whereas before we were using `'machine_time'` and if nothing is passed this was `None` by default. Thus, all the messages from the same detector had the same id e.g. `"4_CoincidenceTier_None"` we did not notice this problem before but now that we have mongo it complains about messages having the exact same id. Replacing this with a utcnow timestamp fixes it. Accordingly, the tests had to be fixed. We also missed it there, all the test cases were testing for `"_id"=="XX_CoincidenceTier_None"`. Now I just check the rest of the keys and not the timestamp. Furthermore, the `snews_cs` has some functions that were checking the `'sent_time'`, apparently we removed it at some point from pt but kept it in cs.

Now that we have a stamp when it is sent (if user also provides a `machine_time` with their timestamp) we can measure the latency between the user submitting and snews_pt publishing. As far as I see this is ~ms levels. 

On the `snews_cs` side we have `"received_time"` and this can tell us the latency between the message being published, and after kafka flight it being received at Purdue. 

So we have;
`"neutrino_time"`  - time of the neutrino burst
"`machine_time`" - the time experiment thinks they sent (optional)
"`sent_time`" - the time we stamp right before `hop.Stream.write()`
"`received_time`" - the time `snews_cs` reads it from the hop stream

Thus, we can infer several latencies.

