### PR TITLE
small fix & cleanup

### DIFF
--- a/snews_pt/__init__.py
+++ b/snews_pt/__init__.py
@@ -3,9 +3,8 @@ try:
 except ImportError:
     pass
 
-import os, click
+import os
 import warnings
-import dotenv
 from dotenv import load_dotenv
 envpath = os.path.join(os.path.dirname(__file__), 'auxiliary/test-config.env')
 load_dotenv(envpath)

--- a/snews_pt/message_schema.py
+++ b/snews_pt/message_schema.py
@@ -1,4 +1,4 @@
-from .snews_pt_utils import get_detector
+from .snews_pt_utils import get_detector, get_name
 from ._version import version as __version__
 
 
@@ -7,17 +7,14 @@ class Message_Schema:
 
     Parameters
     ----------
-    env_path : `str`, optional
-        The path containing the environment configuration file
-        If None, uses the default file in '/auxiliary/test-config.env'
     detector_key : `str`, optional
-        The name of the detector. If None, uses "TEST"
-    alert : `bool`, optional
-        True if the message is ALERT message. Default is False.
+        The name of the detector. If "TEST", looks in the env file
 
     """
 
-    def __init__(self, env_path=None, detector_key='TEST', is_pre_sn=False):
+    def __init__(self, detector_key='TEST', is_pre_sn=False):
+        if detector_key == "TEST":
+            detector_key = get_name()
         self.detector = get_detector(detector_key)
         self.detector_name = self.detector.name
         self.is_pre_sn = is_pre_sn

--- a/snews_pt/snews_pt_utils.py
+++ b/snews_pt/snews_pt_utils.py
@@ -415,3 +415,11 @@ def set_name(detector_name='TEST'):
         os.environ["HAS_NAME_CHANGED"] = "1"
         dotenv.set_key(envpath, "DETECTOR_NAME", os.environ["DETECTOR_NAME"])
         dotenv.set_key(envpath, "HAS_NAME_CHANGED", os.environ["HAS_NAME_CHANGED"])
+
+
+def get_name():
+    """ Get the name of the detector from the
+        env file
+
+    """
+    return os.getenv("DETECTOR_NAME")

--- a/snews_pt/snews_pub.py
+++ b/snews_pt/snews_pub.py
@@ -138,6 +138,8 @@ class SNEWSTiersPublisher:
         kwargs:
             extra stuff you want to send to SNEWS
         """
+        if detector_name == "TEST":
+            detector_name = snews_pt_utils.get_name()
         self.message_data = {'detector_name': detector_name,
                              'machine_time': machine_time,
                              'neutrino_time': neutrino_time,


### PR DESCRIPTION
- cleaned a few unused import statements
- added `get_name()` which looks the name from the env file when it is "TEST"


The second thing is needed as the user modifies the `DETECTOR_NAME` from the env only once. Later, they will want to use that name always, but if we keep the default argument to be `"TEST"` they would still need to pass that each time. This PR fixes that, and they no longer need to pass that after they set it once