### PR TITLE
remove pandas requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,20 +1,11 @@
 click~=8.1.2
-configparser==5.2.0
-docutils==0.17.1
 fixtures==3.0.0
 ipython~=7.32.0
-myst-parser==0.16.1
 mock==4.0.3
 nose==1.3.7
-pandas~=1.4.2
 python-dotenv==0.19.2
-# reno==3.5.0
 setuptools~=62.1.0
 six==1.14.0
-Sphinx==4.2.0
-sphinx_rtd_theme==1.0.0
-sphinx-autoapi==1.8.4
-sphinxcontrib-programoutput==0.17
 testrepository==0.0.20
 testresources==2.0.1
 testscenarios==0.5.0
@@ -24,3 +15,8 @@ wheel==0.34.2
 inquirer==2.9.1
 hop-client~=0.5.0
 attrs~=21.4.0
+docutils==0.17.1
+myst-parser==0.16.1
+sphinx_rtd_theme==1.0.0
+sphinx-autoapi==1.8.4
+sphinxcontrib-programoutput==0.17


### PR DESCRIPTION
Pandas was in the requirements file for snews-pt but is only used by control system