### PR TITLE
fix test-connection

### DIFF
--- a/snews_pt/remote_commands.py
+++ b/snews_pt/remote_commands.py
@@ -27,7 +27,8 @@ def test_connection(detector_name=None, firedrill=True, start_at=-5, wait=10):
         topic = os.getenv("FIREDRILL_OBSERVATION_TOPIC")
     else:
         topic = os.getenv("OBSERVATION_TOPIC")
-    substream = Stream(until_eos=False, auth=True, start_at=start_at)
+    # substream = Stream(until_eos=False, auth=True, start_at=start_at) # when False, while loop doesn't break
+    substream = Stream(until_eos=True, auth=True, start_at=start_at)
     pubstream = Stream(until_eos=True, auth=True)
     click.secho(f"\n> Testing your connection to {topic}. \n> Should take ~{wait} seconds...\n")
 


### PR DESCRIPTION
This fixes the `test-connection` command that gets stuck when there is no connection established. <br>

If the no-firedrill broker is running, you would get a confirmation e.g.;
`test_connection(detector_name="XENONnT", firedrill=False)`<br>
results
```python
> Testing your connection to kafka://kafka.scimma.org/snews.experiments-test. 
> Should take ~10 seconds...

You (XENONnT) have a connection to the server at 2023-02-23T12:53:25.598600
```
When you try firedrill broker which is not running, you shouldn't have connection, and this 
`test_connection(detector_name="XENONnT", firedrill=True)` <br>
results
```python
> Testing your connection to kafka://kafka.scimma.org/snews.experiments-firedrill. 
> Should take ~10 seconds...
	Couldn't get a confirmation in 10 sec. 
	Maybe increase timeout and try again.
```

immediately. Before the fix, the while-time loop was not invoked since the subscription was persistent (similar to alert subscriptions) so it was not ending before it finds the connection or manually killed. Now, the subscription is no longer persistent, it looks for the last few messages and exits.
