### PR TITLE
SQL Database Compatibility

### DIFF
--- a/docs/user/command_line_interface.md
+++ b/docs/user/command_line_interface.md
@@ -76,15 +76,14 @@ instances where this data has been read but could not be send to server right aw
 ```
 In which case it displays the following
 ```bash
-         >The Message Schema for TimeTier
-         _id                 :(SNEWS SETS)
-         schema_version      :(SNEWS SETS)
-         detector_name       :(FETCHED FROM ENV XENONnT)
-         machine_time        :(User Input)
-         neutrino_time       :(User Input)
-         p_val               :(User Input)
-         timing_series       :(User Input*)
-         **kwargs            :(APPENDED AS 'META') 
+         > Message schema for SNEWSTimingTierMessage                                                                               
+         _id                  : (SET AUTOMATICALLY)
+         schema_version       : (SET AUTOMATICALLY)
+         detector_name        : (SET AUTOMATICALLY)
+         timing_series        : (REQUIRED USER INPUT)
+         machine_time         : (USER INPUT)
+         p_val                : (USER INPUT)
+         is_test              : (USER INPUT)
 ```
 or you can simply call `snews_pt message-schema all`  to display all the message schemes. <br>
 

--- a/examples.ipynb
+++ b/examples.ipynb
@@ -13,7 +13,7 @@
    "id": "935f417b",
    "metadata": {},
    "source": [
-    "Last updated: 21/07/2023 <br>\n",
+    "Last updated: 11/12/2023 <br>\n",
     "This notebook contains the most basic publication and subscription examples."
    ]
   },
@@ -27,14 +27,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "0ea6d89a",
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "You are subscribing to \u001b[41m\u001b[1mALERT\u001b[0m\n",
+      "Broker:\u001b[42mkafka://kafka.scimma.org/snews.alert-firedrill\u001b[0m\n",
+      "\u001b[32mDone\u001b[0m\n"
+     ]
+    }
+   ],
    "source": [
     "from snews_pt.snews_sub import Subscriber\n",
     "\n",
@@ -61,7 +71,7 @@
     "\n",
     "Here the argument `neutrino_time` indicates that the message should be sent to \"Coincidence Tier\" for coincidence checks with the other experiments. <br>\n",
     "\n",
-    "Similarly, the input arguments; `p_values` and `t_bin_width` indicates that the message should go to \"Significance Tier\" for combined significance computations using the "
+    "Similarly, the input arguments; `p_values` and `t_bin_width` indicates that the message should go to \"Significance Tier\" for combined significance computations. For more please refer to the documentations."
    ]
   },
   {
@@ -100,7 +110,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 113,
+   "execution_count": 2,
    "id": "81f0b707",
    "metadata": {
     "pycharm": {
@@ -110,9 +120,9 @@
    "outputs": [],
    "source": [
     "from snews_pt import messages\n",
-    "import importlib\n",
-    "importlib.reload(messages)\n",
-    "from datetime import  datetime\n",
+    "# import importlib\n",
+    "# importlib.reload(messages)\n",
+    "from datetime import datetime\n",
     "\n",
     "test_time = datetime.utcnow().isoformat()"
    ]
@@ -136,7 +146,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 3,
    "id": "5a27a67e",
    "metadata": {
     "scrolled": false
@@ -147,44 +157,81 @@
       "text/plain": [
        "[\u001b[1mSNEWSCoincidenceTierMessage\n",
        " \u001b[0m---------------------------\n",
-       " \u001b[91m            _id : LZ_CoincidenceTier_2023-07-31T07:27:00.410593\n",
+       " \u001b[91m            _id : LZ_CoincidenceTier_2023-12-11T15:53:19.155054\n",
        " \u001b[0m\u001b[91m schema_version : 1.3.0\n",
        " \u001b[0m\u001b[91m  detector_name : LZ\n",
-       " \u001b[0m\u001b[94m  neutrino_time : 2023-07-31T07:27:00.410593\n",
-       " \u001b[0m---------------------------\n",
-       " \u001b[96m       p_values : [0.0007, 0.0008, 0.0009]\n",
+       " \u001b[0m\u001b[30m   machine_time : 2023-12-11T15:53:19.155054\n",
+       " \u001b[0m\u001b[94m\u001b[1m  neutrino_time : 2023-12-11T15:53:19.155054\n",
+       " \u001b[0m\u001b[30m          p_val : 0.000\n",
+       " \u001b[0m\u001b[30m        is_test : True\n",
+       " \u001b[0m\u001b[96m       p_values : [0.0007, 0.0008, 0.0009]\n",
        " \u001b[0m\u001b[96m    t_bin_width : 0.07\n",
-       " \u001b[0m\u001b[96m        is_test : True\n",
        " \u001b[0m,\n",
        " \u001b[1mSNEWSSignificanceTierMessage\n",
        " \u001b[0m----------------------------\n",
-       " \u001b[91m            _id : LZ_SignificanceTier_2023-07-31T07:27:00.410593\n",
+       " \u001b[91m            _id : LZ_SignificanceTier_2023-12-11T15:53:19.155054\n",
        " \u001b[0m\u001b[91m schema_version : 1.3.0\n",
        " \u001b[0m\u001b[91m  detector_name : LZ\n",
-       " \u001b[0m\u001b[94m       p_values : [0.0007, 0.0008, 0.0009]\n",
-       " \u001b[0m\u001b[94m    t_bin_width : 0.07\n",
-       " \u001b[0m----------------------------\n",
-       " \u001b[96m  neutrino_time : 2023-07-31T07:27:00.410593\n",
+       " \u001b[0m\u001b[30m   machine_time : 2023-12-11T15:53:19.155054\n",
+       " \u001b[0m\u001b[94m\u001b[1m       p_values : [0.0007, 0.0008, 0.0009]\n",
+       " \u001b[0m\u001b[94m\u001b[1m    t_bin_width : 0.07\n",
+       " \u001b[0m\u001b[30m        is_test : True\n",
+       " \u001b[0m\u001b[96m  neutrino_time : 2023-12-11T15:53:19.155054\n",
        " \u001b[0m\u001b[96m          p_val : 0.000\n",
-       " \u001b[0m\u001b[96m        is_test : True\n",
        " \u001b[0m]"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "msg = messages.SNEWSMessageBuilder(detector_name='LZ', \n",
-    "                          machine_time=test_time, \n",
-    "                          neutrino_time=test_time, \n",
-    "                          p_val=\"0.000\", \n",
-    "                          p_values=[0.0007,0.0008,0.0009],\n",
-    "                          t_bin_width=0.07, \n",
-    "                          is_test=True)\n",
+    "                                   machine_time=test_time, \n",
+    "                                   neutrino_time=test_time, \n",
+    "                                   p_val=\"0.000\", \n",
+    "                                   p_values=[0.0007,0.0008,0.0009],\n",
+    "                                   t_bin_width=0.07, \n",
+    "                                   is_test=True,)\n",
     "\n",
     "msg.messages"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "deda9040",
+   "metadata": {},
+   "source": [
+    "Above the color code refers to the <br>\n",
+    "red:\"base\", (id, version, name) <br>\n",
+    "blue:\"required\", (tier specific) <br>\n",
+    "black:\"accepted\" (machine time, p value, retraction reason etc. known-nonrequired ones) and <br>\n",
+    "green:\"meta\" field arguments."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "dff6f6f4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(['_id', 'schema_version', 'detector_name'],\n",
+       " ['neutrino_time'],\n",
+       " dict_keys(['p_values', 't_bin_width']))"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# msg.messages[0].fields, \n",
+    "msg.messages[0].basefields, msg.messages[0].reqfields, msg.messages[0].meta.keys()"
    ]
   },
   {
@@ -198,7 +245,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "051f5029",
    "metadata": {},
    "outputs": [
@@ -207,16 +254,17 @@
       "text/plain": [
        "[\u001b[1mSNEWSCoincidenceTierMessage\n",
        " \u001b[0m---------------------------\n",
-       " \u001b[91m            _id : LZ_CoincidenceTier_2023-07-21T14:53:51.016430\n",
+       " \u001b[91m            _id : LZ_CoincidenceTier_2023-12-11T15:53:19.155054\n",
        " \u001b[0m\u001b[91m schema_version : 1.3.0\n",
        " \u001b[0m\u001b[91m  detector_name : LZ\n",
-       " \u001b[0m\u001b[94m  neutrino_time : 2023-06-12T18:30:00\n",
-       " \u001b[0m---------------------------\n",
-       " \u001b[96m        is_test : True\n",
+       " \u001b[0m\u001b[30m   machine_time : 2023-12-11T15:53:19.155054\n",
+       " \u001b[0m\u001b[94m\u001b[1m  neutrino_time : 2023-06-12T18:30:00\n",
+       " \u001b[0m\u001b[30m          p_val : None\n",
+       " \u001b[0m\u001b[30m        is_test : True\n",
        " \u001b[0m]"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -248,7 +296,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "43856ed4",
    "metadata": {},
    "outputs": [
@@ -259,7 +307,7 @@
        "No messages have been built."
       ]
      },
-     "execution_count": 5,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -279,29 +327,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "2ac8942a",
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [
-    {
-     "ename": "KeyError",
-     "evalue": "\"aseyhsreshdshdshsdgsdg is not a valid detector. \\nChoose from ['Baksan', 'Borexino', 'DS-20K', 'DUNE', 'HALO', 'HALO-1kT', 'Hyper-K', 'IceCube', 'JUNO', 'KM3NeT', 'KamLAND', 'LVD', 'LZ', 'MicroBooNe', 'NOvA', 'PandaX-4T', 'SBND', 'SNO+', 'Super-K', 'XENONnT']\"",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[10], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m msg \u001b[38;5;241m=\u001b[39m \u001b[43mmessages\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mSNEWSMessageBuilder\u001b[49m\u001b[43m(\u001b[49m\u001b[43mdetector_name\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43maseyhsreshdshdshsdgsdg\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\n\u001b[1;32m      2\u001b[0m \u001b[43m                                  \u001b[49m\u001b[43mmachine_time\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mtest_time\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\n\u001b[1;32m      3\u001b[0m \u001b[43m                                  \u001b[49m\u001b[43mneutrino_time\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mtest_time\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\n\u001b[1;32m      4\u001b[0m \u001b[43m                                  \u001b[49m\u001b[43mp_val\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;241;43m0.0007\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\n\u001b[1;32m      5\u001b[0m \u001b[43m                                  \u001b[49m\u001b[43mp_values\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43m[\u001b[49m\u001b[38;5;241;43m0.0007\u001b[39;49m\u001b[43m,\u001b[49m\u001b[38;5;241;43m0.0008\u001b[39;49m\u001b[43m,\u001b[49m\u001b[38;5;241;43m0.0009\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m      6\u001b[0m \u001b[43m                                  \u001b[49m\u001b[43mt_bin_width\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;241;43m0.07\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\n\u001b[1;32m      7\u001b[0m \u001b[43m                                  \u001b[49m\u001b[43mis_test\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mTrue\u001b[39;49;00m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m/mnt/c/Users/bj7780/Desktop/Kara/GitHub/SNEWS/SNEWS_Publishing_Tools/snews_pt/messages.py:377\u001b[0m, in \u001b[0;36mSNEWSMessageBuilder.__init__\u001b[0;34m(self, env_file, detector_name, machine_time, neutrino_time, p_val, p_values, t_bin_width, timing_series, retract_latest, retraction_reason, detector_status, is_test, **kwargs)\u001b[0m\n\u001b[1;32m    361\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m__init__\u001b[39m(\u001b[38;5;28mself\u001b[39m, env_file\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m,\n\u001b[1;32m    362\u001b[0m              detector_name\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mTEST\u001b[39m\u001b[38;5;124m'\u001b[39m,\n\u001b[1;32m    363\u001b[0m              machine_time\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    372\u001b[0m              is_test\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mFalse\u001b[39;00m,\n\u001b[1;32m    373\u001b[0m              \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs):\n\u001b[1;32m    375\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mmessages \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[0;32m--> 377\u001b[0m     \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_build_messages\u001b[49m\u001b[43m(\u001b[49m\u001b[43menv_file\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43menv_file\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    378\u001b[0m \u001b[43m                         \u001b[49m\u001b[43mdetector_name\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mdetector_name\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    379\u001b[0m \u001b[43m                         \u001b[49m\u001b[43mmachine_time\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mmachine_time\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    380\u001b[0m \u001b[43m                         \u001b[49m\u001b[43mneutrino_time\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mneutrino_time\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    381\u001b[0m \u001b[43m                         \u001b[49m\u001b[43mp_val\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mp_val\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    382\u001b[0m \u001b[43m                         \u001b[49m\u001b[43mp_values\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mp_values\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    383\u001b[0m \u001b[43m                         \u001b[49m\u001b[43mt_bin_width\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mt_bin_width\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    384\u001b[0m \u001b[43m                         \u001b[49m\u001b[43mtiming_series\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mtiming_series\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    385\u001b[0m \u001b[43m                         \u001b[49m\u001b[43mretract_latest\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mretract_latest\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    386\u001b[0m \u001b[43m                         \u001b[49m\u001b[43mretraction_reason\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mretraction_reason\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    387\u001b[0m \u001b[43m                         \u001b[49m\u001b[43mdetector_status\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mdetector_status\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    388\u001b[0m \u001b[43m                         \u001b[49m\u001b[43mis_test\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mis_test\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    389\u001b[0m \u001b[43m                         \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m/mnt/c/Users/bj7780/Desktop/Kara/GitHub/SNEWS/SNEWS_Publishing_Tools/snews_pt/messages.py:439\u001b[0m, in \u001b[0;36mSNEWSMessageBuilder._build_messages\u001b[0;34m(self, **kwargs)\u001b[0m\n\u001b[1;32m    436\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m hasreqfields:\n\u001b[1;32m    437\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mmessages \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[1;32m    438\u001b[0m         \u001b[38;5;66;03m# check is valid at creation\u001b[39;00m\n\u001b[0;32m--> 439\u001b[0m         \u001b[43msmc\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mnonull_kwargs\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241m.\u001b[39mis_valid()\n\u001b[1;32m    440\u001b[0m         \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mmessages \u001b[38;5;241m=\u001b[39m [smc(\u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mnonull_kwargs)]\n\u001b[1;32m    441\u001b[0m     \u001b[38;5;28;01melse\u001b[39;00m:\n",
-      "File \u001b[0;32m/mnt/c/Users/bj7780/Desktop/Kara/GitHub/SNEWS/SNEWS_Publishing_Tools/snews_pt/messages.py:243\u001b[0m, in \u001b[0;36mSNEWSCoincidenceTierMessage.__init__\u001b[0;34m(self, neutrino_time, p_val, **kwargs)\u001b[0m\n\u001b[1;32m    242\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m__init__\u001b[39m(\u001b[38;5;28mself\u001b[39m, neutrino_time\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m, p_val\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs):\n\u001b[0;32m--> 243\u001b[0m     \u001b[38;5;28;43msuper\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[38;5;21;43m__init__\u001b[39;49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mfields\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    244\u001b[0m \u001b[43m                     \u001b[49m\u001b[43mneutrino_time\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mclean_time_input\u001b[49m\u001b[43m(\u001b[49m\u001b[43mneutrino_time\u001b[49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    245\u001b[0m \u001b[43m                     \u001b[49m\u001b[43mp_val\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mp_val\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    246\u001b[0m \u001b[43m                     \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m/mnt/c/Users/bj7780/Desktop/Kara/GitHub/SNEWS/SNEWS_Publishing_Tools/snews_pt/messages.py:119\u001b[0m, in \u001b[0;36mSNEWSMessage.__init__\u001b[0;34m(self, fields, detector_name, machine_time, **kwargs)\u001b[0m\n\u001b[1;32m    115\u001b[0m tier \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__class__\u001b[39m\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m\u001b[38;5;241m.\u001b[39mreplace(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mSNEWS\u001b[39m\u001b[38;5;124m'\u001b[39m,\u001b[38;5;124m'\u001b[39m\u001b[38;5;124m'\u001b[39m)\u001b[38;5;241m.\u001b[39mreplace(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mMessage\u001b[39m\u001b[38;5;124m'\u001b[39m,\u001b[38;5;124m'\u001b[39m\u001b[38;5;124m'\u001b[39m)\n\u001b[1;32m    117\u001b[0m \u001b[38;5;66;03m# Get the detector name from the input.\u001b[39;00m\n\u001b[1;32m    118\u001b[0m \u001b[38;5;66;03m# det = self.get_detector_name(detector_name)\u001b[39;00m\n\u001b[0;32m--> 119\u001b[0m det \u001b[38;5;241m=\u001b[39m \u001b[43msnews_pt_utils\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mset_name\u001b[49m\u001b[43m(\u001b[49m\u001b[43mdetector_name\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43m_return\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mTrue\u001b[39;49;00m\u001b[43m)\u001b[49m\n\u001b[1;32m    120\u001b[0m mt \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mclean_time_input(machine_time)\n\u001b[1;32m    122\u001b[0m \u001b[38;5;66;03m# Store basic message ID, detector name, and schema in a dictionary.\u001b[39;00m\n",
-      "File \u001b[0;32m/mnt/c/Users/bj7780/Desktop/Kara/GitHub/SNEWS/SNEWS_Publishing_Tools/snews_pt/snews_pt_utils.py:319\u001b[0m, in \u001b[0;36mset_name\u001b[0;34m(detector_name, _return)\u001b[0m\n\u001b[1;32m    317\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[1;32m    318\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m detector_name \u001b[38;5;129;01min\u001b[39;00m detectors:\n\u001b[0;32m--> 319\u001b[0m         \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mdetector_name\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m is not a valid detector. \u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;124mChoose from \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mdetectors\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m    320\u001b[0m     os\u001b[38;5;241m.\u001b[39menviron[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mDETECTOR_NAME\u001b[39m\u001b[38;5;124m\"\u001b[39m] \u001b[38;5;241m=\u001b[39m detector_name\n\u001b[1;32m    321\u001b[0m     os\u001b[38;5;241m.\u001b[39menviron[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mHAS_NAME_CHANGED\u001b[39m\u001b[38;5;124m\"\u001b[39m] \u001b[38;5;241m=\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m1\u001b[39m\u001b[38;5;124m\"\u001b[39m\n",
-      "\u001b[0;31mKeyError\u001b[0m: \"aseyhsreshdshdshsdgsdg is not a valid detector. \\nChoose from ['Baksan', 'Borexino', 'DS-20K', 'DUNE', 'HALO', 'HALO-1kT', 'Hyper-K', 'IceCube', 'JUNO', 'KM3NeT', 'KamLAND', 'LVD', 'LZ', 'MicroBooNe', 'NOvA', 'PandaX-4T', 'SBND', 'SNO+', 'Super-K', 'XENONnT']\""
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "1cf2031b",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "msg = messages.SNEWSMessageBuilder(detector_name='aseyhsreshdshdshsdgsdg', \n",
     "                                  machine_time=test_time, \n",
@@ -322,17 +351,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "0cbbf351",
+   "execution_count": null,
+   "id": "b0dcfb0e",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# msg = messages.SNEWSMessageBuilder(detector_name='LZ', \n",
-    "#                           machine_time=test_time, \n",
-    "#                           neutrino_time=\"2023-06-12 18:30\",  \n",
-    "#                           is_test=False)\n",
-    "\n",
-    "# msg.messages"
+    "msg = messages.SNEWSMessageBuilder(detector_name='LZ', \n",
+    "                                  machine_time=test_time, \n",
+    "                                  neutrino_time=\"2023-06-12 18:30\",  \n",
+    "                                  is_test=False)"
    ]
   },
   {
@@ -345,18 +372,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "31a36522",
+   "execution_count": null,
+   "id": "eb955586",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# msg = messages.SNEWSMessageBuilder(detector_name='LZ', \n",
-    "#                                    machine_time=test_time, \n",
-    "#                                    p_values=[-0.0007,0.0008,0.0009],\n",
-    "#                                    t_bin_width=0.07, \n",
-    "#                                    is_test=False)\n",
-    "\n",
-    "# msg.messages"
+    "msg = messages.SNEWSMessageBuilder(detector_name='LZ', \n",
+    "                                   machine_time=test_time, \n",
+    "                                   p_values=[-0.0007,0.0008,0.0009],\n",
+    "                                   t_bin_width=0.07, \n",
+    "                                   is_test=False)"
    ]
   },
   {
@@ -369,7 +394,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "id": "45f72227",
    "metadata": {},
    "outputs": [],
@@ -380,34 +405,33 @@
     "                                  p_val=\"0.000\", \n",
     "                                  p_values=[0.0007,0.0008,0.0009],\n",
     "                                  t_bin_width=0.07, \n",
-    "                                  is_test=True)"
+    "                                  is_test=True,)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "id": "cfe4b55a",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "\u001b[1mSNEWSCoincidenceTierMessage\n",
        "\u001b[0m---------------------------\n",
-       "\u001b[91m            _id : LZ_CoincidenceTier_2023-07-21T14:53:51.016430\n",
+       "\u001b[91m            _id : LZ_CoincidenceTier_2023-12-11T15:53:19.155054\n",
        "\u001b[0m\u001b[91m schema_version : 1.3.0\n",
        "\u001b[0m\u001b[91m  detector_name : LZ\n",
-       "\u001b[0m\u001b[94m  neutrino_time : 2023-07-21T14:53:51.016430\n",
-       "\u001b[0m---------------------------\n",
-       "\u001b[96m       p_values : [0.0007, 0.0008, 0.0009]\n",
+       "\u001b[0m\u001b[30m   machine_time : 2023-12-11T15:53:19.155054\n",
+       "\u001b[0m\u001b[94m\u001b[1m  neutrino_time : 2023-12-11T15:53:19.155054\n",
+       "\u001b[0m\u001b[30m          p_val : 0.000\n",
+       "\u001b[0m\u001b[30m        is_test : True\n",
+       "\u001b[0m\u001b[96m       p_values : [0.0007, 0.0008, 0.0009]\n",
        "\u001b[0m\u001b[96m    t_bin_width : 0.07\n",
-       "\u001b[0m\u001b[96m        is_test : True\n",
        "\u001b[0m"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -418,7 +442,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 9,
    "id": "09d73658",
    "metadata": {},
    "outputs": [
@@ -428,22 +452,26 @@
      "text": [
       "\u001b[94m----------------------------------------------------------------\u001b[0m\n",
       "\u001b[91mSending message to CoincidenceTier on kafka://kafka.scimma.org/snews.experiments-firedrill\u001b[0m\n",
-      "_id                :LZ_CoincidenceTier_2023-07-21T14:53:51.016430\n",
+      "_id                :LZ_CoincidenceTier_2023-12-11T15:45:15.394059\n",
       "schema_version     :1.3.0\n",
       "detector_name      :LZ\n",
-      "neutrino_time      :2023-07-21T14:53:51.016430\n",
+      "machine_time       :2023-12-11T15:45:15.394059\n",
+      "neutrino_time      :2023-12-11T15:45:15.394059\n",
       "p_val              :0.000\n",
       "is_test            :True\n",
-      "sent_time          :2023-07-21T14:54:09.738349\n",
+      "meta               :\n",
+      "sent_time          :2023-12-11T15:45:45.677277\n",
       "\u001b[94m----------------------------------------------------------------\u001b[0m\n",
       "\u001b[91mSending message to SignificanceTier on kafka://kafka.scimma.org/snews.experiments-firedrill\u001b[0m\n",
-      "_id                :LZ_SignificanceTier_2023-07-21T14:53:51.016430\n",
+      "_id                :LZ_SignificanceTier_2023-12-11T15:45:15.394059\n",
       "schema_version     :1.3.0\n",
       "detector_name      :LZ\n",
+      "machine_time       :2023-12-11T15:45:15.394059\n",
       "p_values           :[0.0007, 0.0008, 0.0009]\n",
       "t_bin_width        :0.07\n",
       "is_test            :True\n",
-      "sent_time          :2023-07-21T14:54:09.741139\n"
+      "meta               :\n",
+      "sent_time          :2023-12-11T15:45:45.679676\n"
      ]
     }
    ],
@@ -462,24 +490,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 10,
    "id": "08e5425c",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "({'_id': 'LZ_CoincidenceTier_2023-07-21T14:53:51.016430',\n",
+       "({'_id': 'LZ_CoincidenceTier_2023-12-11T15:53:19.155054',\n",
        "  'schema_version': '1.3.0',\n",
        "  'detector_name': 'LZ',\n",
-       "  'neutrino_time': '2023-07-21T14:53:51.016430',\n",
+       "  'machine_time': '2023-12-11T15:53:19.155054',\n",
+       "  'neutrino_time': '2023-12-11T15:53:19.155054',\n",
        "  'p_val': '0.000',\n",
-       "  'is_test': True,\n",
-       "  'sent_time': '2023-07-21T14:54:09.738349'},\n",
-       " {'p_values': [0.0007, 0.0008, 0.0009], 't_bin_width': 0.07, 'is_test': True})"
+       "  'is_test': True},\n",
+       " {'p_values': [0.0007, 0.0008, 0.0009], 't_bin_width': 0.07})"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -490,26 +518,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 11,
    "id": "eea25d44",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "({'_id': 'LZ_SignificanceTier_2023-07-21T14:53:51.016430',\n",
+       "({'_id': 'LZ_SignificanceTier_2023-12-11T15:53:19.155054',\n",
        "  'schema_version': '1.3.0',\n",
        "  'detector_name': 'LZ',\n",
+       "  'machine_time': '2023-12-11T15:53:19.155054',\n",
        "  'p_values': [0.0007, 0.0008, 0.0009],\n",
        "  't_bin_width': 0.07,\n",
-       "  'is_test': True,\n",
-       "  'sent_time': '2023-07-21T14:54:09.741139'},\n",
-       " {'neutrino_time': '2023-07-21T14:53:51.016430',\n",
-       "  'p_val': '0.000',\n",
-       "  'is_test': True})"
+       "  'is_test': True},\n",
+       " {'neutrino_time': '2023-12-11T15:53:19.155054', 'p_val': '0.000'})"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -528,7 +554,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 12,
    "id": "0625292e",
    "metadata": {},
    "outputs": [
@@ -542,7 +568,8 @@
       "\u001b[91mdetector_name        : (SET AUTOMATICALLY)\u001b[0m\n",
       "\u001b[94mneutrino_time        : (REQUIRED USER INPUT)\u001b[0m\n",
       "\u001b[96mmachine_time         : (USER INPUT)\u001b[0m\n",
-      "\u001b[96mp_val                : (USER INPUT)\u001b[0m\n"
+      "\u001b[96mp_val                : (USER INPUT)\u001b[0m\n",
+      "\u001b[96mis_test              : (USER INPUT)\u001b[0m\n"
      ]
     }
    ],
@@ -552,7 +579,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 13,
    "id": "4177e2c5",
    "metadata": {},
    "outputs": [
@@ -566,7 +593,8 @@
       "\u001b[91mdetector_name        : (SET AUTOMATICALLY)\u001b[0m\n",
       "\u001b[94mp_values             : (REQUIRED USER INPUT)\u001b[0m\n",
       "\u001b[94mt_bin_width          : (REQUIRED USER INPUT)\u001b[0m\n",
-      "\u001b[96mmachine_time         : (USER INPUT)\u001b[0m\n"
+      "\u001b[96mmachine_time         : (USER INPUT)\u001b[0m\n",
+      "\u001b[96mis_test              : (USER INPUT)\u001b[0m\n"
      ]
     }
    ],

--- a/firedrill.ipynb
+++ b/firedrill.ipynb
@@ -64,12 +64,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
     "from snews_pt.snews_pt_utils import set_name                       # to set experiment name\n",
-    "# from snews_pt.snews_pub import SNEWSTiersPublisher                 # to publish observations & heartbeats\n",
     "from snews_pt.messages import SNEWSMessageBuilder\n",
     "from snews_pt.snews_sub import Subscriber                          # to listen alerts\n",
     "from snews_pt.remote_commands import test_connection, get_feedback # to test connection and get feedback\n",
@@ -86,14 +85,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "You are XENONnT\u001b[0m\n"
+      "You are LZ\u001b[0m\n"
      ]
     }
    ],
@@ -124,6 +123,13 @@
       "Broker:\u001b[42mkafka://kafka.scimma.org/snews.alert-firedrill\u001b[0m\n",
       "\u001b[32mDone\u001b[0m\n"
      ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "%3|1696422764.498|FAIL|rdkafka#consumer-1| [thrd:sasl_ssl://kb-2.prod.hop.scimma.org:9092/2]: sasl_ssl://kb-2.prod.hop.scimma.org:9092/2: SASL authentication error: SaslAuthenticateRequest failed: Local: Broker handle destroyed (after 5ms in state DOWN)\n"
+     ]
     }
    ],
    "source": [
@@ -140,7 +146,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -157,27 +163,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [
-    {
-     "ename": "ValueError",
-     "evalue": "Invalid isoformat string: '2023-06-9999999:45:100000'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[5], line 2\u001b[0m\n\u001b[1;32m      1\u001b[0m observation_time2 \u001b[38;5;241m=\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m2023-06-9999999:45:100000\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[0;32m----> 2\u001b[0m msg2 \u001b[38;5;241m=\u001b[39m \u001b[43mSNEWSMessageBuilder\u001b[49m\u001b[43m(\u001b[49m\u001b[43mneutrino_time\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mobservation_time2\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mis_test\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mTrue\u001b[39;49;00m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mfiredrill_mode\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mTrue\u001b[39;49;00m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m/mnt/c/Users/bj7780/Desktop/Kara/GitHub/SNEWS/SNEWS_Publishing_Tools/snews_pt/messages.py:385\u001b[0m, in \u001b[0;36mSNEWSMessageBuilder.__init__\u001b[0;34m(self, env_file, detector_name, machine_time, neutrino_time, p_val, p_values, t_bin_width, timing_series, retract_latest, retraction_reason, detector_status, is_test, **kwargs)\u001b[0m\n\u001b[1;32m    382\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mmessages \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[1;32m    383\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mselected_tiers \u001b[38;5;241m=\u001b[39m []\n\u001b[0;32m--> 385\u001b[0m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_build_messages\u001b[49m\u001b[43m(\u001b[49m\u001b[43menv_file\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43menv_file\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    386\u001b[0m \u001b[43m                     \u001b[49m\u001b[43mdetector_name\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mdetector_name\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    387\u001b[0m \u001b[43m                     \u001b[49m\u001b[43mmachine_time\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mmachine_time\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    388\u001b[0m \u001b[43m                     \u001b[49m\u001b[43mneutrino_time\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mneutrino_time\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    389\u001b[0m \u001b[43m                     \u001b[49m\u001b[43mp_val\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mp_val\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    390\u001b[0m \u001b[43m                     \u001b[49m\u001b[43mp_values\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mp_values\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    391\u001b[0m \u001b[43m                     \u001b[49m\u001b[43mt_bin_width\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mt_bin_width\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    392\u001b[0m \u001b[43m                     \u001b[49m\u001b[43mtiming_series\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mtiming_series\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    393\u001b[0m \u001b[43m                     \u001b[49m\u001b[43mretract_latest\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mretract_latest\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    394\u001b[0m \u001b[43m                     \u001b[49m\u001b[43mretraction_reason\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mretraction_reason\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    395\u001b[0m \u001b[43m                     \u001b[49m\u001b[43mdetector_status\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mdetector_status\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    396\u001b[0m \u001b[43m                     \u001b[49m\u001b[43mis_test\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mis_test\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    397\u001b[0m \u001b[43m                     \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m/mnt/c/Users/bj7780/Desktop/Kara/GitHub/SNEWS/SNEWS_Publishing_Tools/snews_pt/messages.py:447\u001b[0m, in \u001b[0;36mSNEWSMessageBuilder._build_messages\u001b[0;34m(self, **kwargs)\u001b[0m\n\u001b[1;32m    444\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m hasreqfields:\n\u001b[1;32m    445\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mmessages \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[1;32m    446\u001b[0m         \u001b[38;5;66;03m# check is valid at creation\u001b[39;00m\n\u001b[0;32m--> 447\u001b[0m         \u001b[43msmc\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mnonull_kwargs\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241m.\u001b[39mis_valid()\n\u001b[1;32m    448\u001b[0m         \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mmessages \u001b[38;5;241m=\u001b[39m [smc(\u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mnonull_kwargs)]\n\u001b[1;32m    449\u001b[0m     \u001b[38;5;28;01melse\u001b[39;00m:\n",
-      "File \u001b[0;32m/mnt/c/Users/bj7780/Desktop/Kara/GitHub/SNEWS/SNEWS_Publishing_Tools/snews_pt/messages.py:247\u001b[0m, in \u001b[0;36mSNEWSCoincidenceTierMessage.__init__\u001b[0;34m(self, neutrino_time, p_val, **kwargs)\u001b[0m\n\u001b[1;32m    245\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m__init__\u001b[39m(\u001b[38;5;28mself\u001b[39m, neutrino_time\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m, p_val\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs):\n\u001b[1;32m    246\u001b[0m     \u001b[38;5;28msuper\u001b[39m()\u001b[38;5;241m.\u001b[39m\u001b[38;5;21m__init__\u001b[39m(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mfields,\n\u001b[0;32m--> 247\u001b[0m                      neutrino_time\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mclean_time_input\u001b[49m\u001b[43m(\u001b[49m\u001b[43mneutrino_time\u001b[49m\u001b[43m)\u001b[49m,\n\u001b[1;32m    248\u001b[0m                      p_val\u001b[38;5;241m=\u001b[39mp_val,\n\u001b[1;32m    249\u001b[0m                      \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs)\n",
-      "File \u001b[0;32m/mnt/c/Users/bj7780/Desktop/Kara/GitHub/SNEWS/SNEWS_Publishing_Tools/snews_pt/messages.py:188\u001b[0m, in \u001b[0;36mSNEWSMessage.clean_time_input\u001b[0;34m(self, time)\u001b[0m\n\u001b[1;32m    185\u001b[0m     time \u001b[38;5;241m=\u001b[39m datetime\u001b[38;5;241m.\u001b[39mutcnow()\n\u001b[1;32m    187\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(time, \u001b[38;5;28mstr\u001b[39m):\n\u001b[0;32m--> 188\u001b[0m     time \u001b[38;5;241m=\u001b[39m \u001b[43mfromisoformat\u001b[49m\u001b[43m(\u001b[49m\u001b[43mtime\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    190\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m time\u001b[38;5;241m.\u001b[39misoformat()\n",
-      "\u001b[0;31mValueError\u001b[0m: Invalid isoformat string: '2023-06-9999999:45:100000'"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "observation_time2 = \"2023-06-9999999:45:100000\"\n",
     "msg2 = SNEWSMessageBuilder(neutrino_time=observation_time2, is_test=True, firedrill_mode=True)"
@@ -214,7 +202,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -232,7 +220,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -241,7 +229,7 @@
        "['SNEWSCoincidenceTierMessage', 'SNEWSHeartbeatMessage']"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -253,7 +241,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -268,29 +256,30 @@
       "text/plain": [
        "[\u001b[1mSNEWSCoincidenceTierMessage\n",
        " \u001b[0m---------------------------\n",
-       " \u001b[91m            _id : TEST_CoincidenceTier_2023-07-31T09:15:14.352389\n",
+       " \u001b[91m            _id : LZ_CoincidenceTier_2023-12-11T15:57:06.977210\n",
        " \u001b[0m\u001b[91m schema_version : 1.3.0\n",
-       " \u001b[0m\u001b[91m  detector_name : TEST\n",
-       " \u001b[0m\u001b[94m  neutrino_time : 2023-06-14T12:45:45.100000\n",
-       " \u001b[0m---------------------------\n",
-       " \u001b[96mdetector_status : ON\n",
-       " \u001b[0m\u001b[96m        is_test : True\n",
+       " \u001b[0m\u001b[91m  detector_name : LZ\n",
+       " \u001b[0m\u001b[30m   machine_time : None\n",
+       " \u001b[0m\u001b[94m\u001b[1m  neutrino_time : 2023-06-14T12:45:45.100000\n",
+       " \u001b[0m\u001b[30m          p_val : None\n",
+       " \u001b[0m\u001b[30m        is_test : True\n",
+       " \u001b[0m\u001b[96mdetector_status : ON\n",
        " \u001b[0m\u001b[96m firedrill_mode : True\n",
        " \u001b[0m,\n",
        " \u001b[1mSNEWSHeartbeatMessage\n",
        " \u001b[0m---------------------\n",
-       " \u001b[91m            _id : TEST_Heartbeat_2023-07-31T09:15:14.363811\n",
+       " \u001b[91m            _id : LZ_Heartbeat_2023-12-11T15:57:06.977247\n",
        " \u001b[0m\u001b[91m schema_version : 1.3.0\n",
-       " \u001b[0m\u001b[91m  detector_name : TEST\n",
-       " \u001b[0m\u001b[94mdetector_status : ON\n",
-       " \u001b[0m---------------------\n",
-       " \u001b[96m  neutrino_time : 2023-06-14T12:45:45.100000\n",
-       " \u001b[0m\u001b[96m        is_test : True\n",
+       " \u001b[0m\u001b[91m  detector_name : LZ\n",
+       " \u001b[0m\u001b[30m   machine_time : None\n",
+       " \u001b[0m\u001b[94m\u001b[1mdetector_status : ON\n",
+       " \u001b[0m\u001b[30m        is_test : True\n",
+       " \u001b[0m\u001b[96m  neutrino_time : 2023-06-14T12:45:45.100000\n",
        " \u001b[0m\u001b[96m firedrill_mode : True\n",
        " \u001b[0m]"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -304,7 +293,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -312,18 +301,19 @@
       "text/plain": [
        "\u001b[1mSNEWSCoincidenceTierMessage\n",
        "\u001b[0m---------------------------\n",
-       "\u001b[91m            _id : TEST_CoincidenceTier_2023-07-31T09:15:14.352389\n",
+       "\u001b[91m            _id : LZ_CoincidenceTier_2023-12-11T15:57:06.977210\n",
        "\u001b[0m\u001b[91m schema_version : 1.3.0\n",
-       "\u001b[0m\u001b[91m  detector_name : TEST\n",
-       "\u001b[0m\u001b[94m  neutrino_time : 2023-06-14T12:45:45.100000\n",
-       "\u001b[0m---------------------------\n",
-       "\u001b[96mdetector_status : ON\n",
-       "\u001b[0m\u001b[96m        is_test : True\n",
+       "\u001b[0m\u001b[91m  detector_name : LZ\n",
+       "\u001b[0m\u001b[30m   machine_time : None\n",
+       "\u001b[0m\u001b[94m\u001b[1m  neutrino_time : 2023-06-14T12:45:45.100000\n",
+       "\u001b[0m\u001b[30m          p_val : None\n",
+       "\u001b[0m\u001b[30m        is_test : True\n",
+       "\u001b[0m\u001b[96mdetector_status : ON\n",
        "\u001b[0m\u001b[96m firedrill_mode : True\n",
        "\u001b[0m"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -335,7 +325,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -343,18 +333,18 @@
       "text/plain": [
        "\u001b[1mSNEWSHeartbeatMessage\n",
        "\u001b[0m---------------------\n",
-       "\u001b[91m            _id : TEST_Heartbeat_2023-07-31T09:15:14.363811\n",
+       "\u001b[91m            _id : LZ_Heartbeat_2023-12-11T15:57:06.977247\n",
        "\u001b[0m\u001b[91m schema_version : 1.3.0\n",
-       "\u001b[0m\u001b[91m  detector_name : TEST\n",
-       "\u001b[0m\u001b[94mdetector_status : ON\n",
-       "\u001b[0m---------------------\n",
-       "\u001b[96m  neutrino_time : 2023-06-14T12:45:45.100000\n",
-       "\u001b[0m\u001b[96m        is_test : True\n",
+       "\u001b[0m\u001b[91m  detector_name : LZ\n",
+       "\u001b[0m\u001b[30m   machine_time : None\n",
+       "\u001b[0m\u001b[94m\u001b[1mdetector_status : ON\n",
+       "\u001b[0m\u001b[30m        is_test : True\n",
+       "\u001b[0m\u001b[96m  neutrino_time : 2023-06-14T12:45:45.100000\n",
        "\u001b[0m\u001b[96m firedrill_mode : True\n",
        "\u001b[0m"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -380,7 +370,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -393,17 +383,16 @@
       "> Expecting from kafka://kafka.scimma.org/snews.connection-testing. \n",
       "> Going to wait 8 seconds before checking for confirmation...\n",
       "\u001b[0m\n",
-      "\u001b[31m\u001b[1m\tWaited for 8 sec and checked from LATEST, couldn't get a confirmation\n",
-      "\tMaybe increase timeout and try again.\u001b[0m\n"
+      "You (\u001b[32m\u001b[1mLZ\u001b[0m) have a connection to the server at \u001b[32m\u001b[1m2023-12-11T15:57:36.411812\u001b[0m\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "False"
+       "True"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -416,7 +405,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There were no connection! This is because at the moment, server runs the coincidence logic on the non-firedrill broker, and we were trying to test our connection to the firedrill! <br>\n",
+    "There was no connection! This is because at the moment, server runs the coincidence logic on the non-firedrill broker, and we were trying to test our connection to the firedrill! <br>\n",
     "```bash\n",
     "> Sending to kafka://kafka.scimma.org/snews.experiments-firedrill\n",
     "```\n",
@@ -425,7 +414,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 11,
    "metadata": {
     "scrolled": true
    },
@@ -440,7 +429,7 @@
       "> Expecting from kafka://kafka.scimma.org/snews.connection-testing. \n",
       "> Going to wait 8 seconds before checking for confirmation...\n",
       "\u001b[0m\n",
-      "You (\u001b[32m\u001b[1mXENONnT\u001b[0m) have a connection to the server at \u001b[32m\u001b[1m2023-07-31T09:16:54.159806\u001b[0m\n"
+      "You (\u001b[32m\u001b[1mLZ\u001b[0m) have a connection to the server at \u001b[32m\u001b[1m2023-12-11T15:58:18.989221\u001b[0m\n"
      ]
     },
     {
@@ -449,19 +438,18 @@
        "True"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "from snews_pt.remote_commands import test_connection\n",
     "test_connection(firedrill=False, patience=8)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -470,7 +458,7 @@
      "text": [
       "\u001b[94m----------------------------------------------------------------\u001b[0m\n",
       "\u001b[91mSending message to CoincidenceTier on kafka://kafka.scimma.org/snews.experiments-test\u001b[0m\n",
-      "_id                :TEST_CoincidenceTier_2023-07-31T09:15:14.352389\n",
+      "_id                :TEST_CoincidenceTier_2023-10-04T12:34:58.853532\n",
       "schema_version     :1.3.0\n",
       "detector_name      :TEST\n",
       "machine_time       :None\n",
@@ -478,17 +466,17 @@
       "p_val              :None\n",
       "is_test            :True\n",
       "firedrill_mode     :True\n",
-      "sent_time          :2023-07-31T09:17:37.096038\n",
+      "sent_time          :2023-10-04T12:35:30.621625\n",
       "\u001b[94m----------------------------------------------------------------\u001b[0m\n",
       "\u001b[91mSending message to Heartbeat on kafka://kafka.scimma.org/snews.experiments-test\u001b[0m\n",
-      "_id                :TEST_Heartbeat_2023-07-31T09:15:14.363811\n",
+      "_id                :TEST_Heartbeat_2023-10-04T12:34:58.864538\n",
       "schema_version     :1.3.0\n",
       "detector_name      :TEST\n",
       "machine_time       :None\n",
       "detector_status    :ON\n",
       "is_test            :True\n",
       "firedrill_mode     :True\n",
-      "sent_time          :2023-07-31T09:17:37.097456\n"
+      "sent_time          :2023-10-04T12:35:30.623876\n"
      ]
     }
    ],
@@ -506,7 +494,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -514,18 +502,19 @@
       "text/plain": [
        "(\u001b[1mSNEWSCoincidenceTierMessage\n",
        " \u001b[0m---------------------------\n",
-       " \u001b[91m            _id : TEST_CoincidenceTier_2023-07-31T09:18:01.695375\n",
+       " \u001b[91m            _id : LZ_CoincidenceTier_2023-12-11T15:58:43.669916\n",
        " \u001b[0m\u001b[91m schema_version : 1.3.0\n",
-       " \u001b[0m\u001b[91m  detector_name : TEST\n",
-       " \u001b[0m\u001b[94m  neutrino_time : 2023-06-14T12:45:45.100000\n",
-       " \u001b[0m---------------------------\n",
-       " \u001b[96m        is_test : True\n",
+       " \u001b[0m\u001b[91m  detector_name : LZ\n",
+       " \u001b[0m\u001b[30m   machine_time : None\n",
+       " \u001b[0m\u001b[94m\u001b[1m  neutrino_time : 2023-06-14T12:45:45.100000\n",
+       " \u001b[0m\u001b[30m          p_val : None\n",
+       " \u001b[0m\u001b[30m        is_test : True\n",
        " \u001b[0m\u001b[96m        comment : We were taking calibration data\n",
        " \u001b[0m,\n",
-       " {'is_test': True, 'comment': 'We were taking calibration data'})"
+       " {'comment': 'We were taking calibration data'})"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1046,13 +1035,6 @@
    "source": [
     "- 5. send your observation to snews"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "code",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-click~=8.1.2
+click>=8.1.2
 fixtures==3.0.0
 ipython~=7.32.0
 mock==4.0.3
 nose==1.3.7
 python-dotenv==0.19.2
-setuptools~=62.1.0
+setuptools>=62.1.0
 six==1.14.0
 testrepository==0.0.20
 testresources==2.0.1
@@ -14,11 +14,11 @@ virtualenv==20.13.0
 wheel==0.34.2
 inquirer>=2.8.0
 hop-client==0.8.0
-attrs~=21.4.0
+attrs>=21.4.0
 docutils==0.17.1
 myst-parser==0.16.1
 sphinx_rtd_theme==1.0.0
 sphinx-autoapi==1.8.4
 sphinxcontrib-programoutput==0.17
-pytest~=6.2.5
+pytest>=6.2.5
 numpy>=1.22.3

--- a/snews_pt/__main__.py
+++ b/snews_pt/__main__.py
@@ -123,18 +123,12 @@ def message_schema(ctx, requested_tier):
             tier = list(tier_data_pairs.keys())
         else:
             # check for aliases e.g. coinc = coincidence = CoinCideNceTier
-            tier = snews_pt_utils._check_aliases(requested_tier[0])
+            tier = list(snews_pt_utils._check_aliases(requested_tier[0]))
 
     for t in tier:
-        TierMessage = tier_data_pairs[t]
-        click.secho(f'Message schema for {TierMessage.__name__}', bg='white', fg='blue')
-        for f in TierMessage.fields:
-            if f in TierMessage.basefields:
-                click.secho(f'{f:<20s} : (SET AUTOMATICALLY)', fg='bright_red')
-            elif f in TierMessage.reqfields:
-                click.secho(f'{f:<20s} : (REQUIRED USER INPUT)', fg='bright_blue')
-            else:
-                click.secho(f'{f:<20s} : (USER INPUT)', fg='bright_cyan')
+        TierMessage = tier_data_pairs[t]()
+        TierMessage.print_schema()
+
         
 
 @main.command()

--- a/snews_pt/__main__.py
+++ b/snews_pt/__main__.py
@@ -106,7 +106,8 @@ def message_schema(ctx, requested_tier):
         displays everything
     """
     from .messages import SNEWSHeartbeatMessage, SNEWSTimingTierMessage, SNEWSSignificanceTierMessage, \
-        SNEWSCoincidenceTierMessage, SNEWSRetractionMessage
+        SNEWSCoincidenceTierMessage, SNEWSRetractionMessage, SNEWSMessage
+
     tier_data_pairs = {'CoincidenceTier': SNEWSCoincidenceTierMessage,
                        'SigTier': SNEWSSignificanceTierMessage,
                        'TimeTier': SNEWSTimingTierMessage,
@@ -125,11 +126,20 @@ def message_schema(ctx, requested_tier):
             # check for aliases e.g. coinc = coincidence = CoinCideNceTier
             tier = list(snews_pt_utils._check_aliases(requested_tier[0]))
 
+    basefields = SNEWSMessage.basefields
     for t in tier:
-        TierMessage = tier_data_pairs[t]()
-        TierMessage.print_schema()
-
-        
+        TierMessage = tier_data_pairs[t]
+        fields = TierMessage.fields
+        reqfields = TierMessage.reqfields
+        click.secho(f'Message schema for {t}', bg='white', fg='blue')
+        for f in fields:
+            if f in basefields:
+                click.secho(f'{f:<20s} : (SET AUTOMATICALLY)', fg='bright_red')
+            elif f in reqfields:
+                click.secho(f'{f:<20s} : (REQUIRED USER INPUT)', fg='bright_blue')
+            else:
+                click.secho(f'{f:<20s} : (USER INPUT)', fg='bright_cyan')
+        click.secho(f'{"**kwargs":<20s} : (GROUPED AS META)', fg='bright_green')
 
 @main.command()
 @click.option('--firedrill/--no-firedrill', default=True, show_default='True', help='Whether to use firedrill brokers or default ones')

--- a/snews_pt/_version.py
+++ b/snews_pt/_version.py
@@ -1,1 +1,1 @@
-version = '1.3.0'
+version = '1.3.1'

--- a/snews_pt/messages.py
+++ b/snews_pt/messages.py
@@ -150,6 +150,7 @@ class SNEWSMessage(ABC):
                 click.secho(f'{f:<20s} : (REQUIRED USER INPUT)', fg='bright_blue')
             else:
                 click.secho(f'{f:<20s} : (USER INPUT)', fg='bright_cyan')
+        click.secho(f'{"**kwargs":<20s} : (GROUPED AS META)', fg='bright_green')
 
     def get_detector_name(self, detector_name):
         """Get formatted detector name.

--- a/snews_pt/messages.py
+++ b/snews_pt/messages.py
@@ -280,10 +280,6 @@ class SNEWSSignificanceTierMessage(SNEWSMessage):
     fields = SNEWSMessage.basefields + reqfields + [ 'machine_time', 'is_test' ]
 
     def __init__(self, p_values=None, t_bin_width=None, **kwargs):
-        # Type check for proper types.
-        if np.isscalar(p_values):
-            raise RuntimeError(f'{self.__class__.__name__} p_values must be a list.')
-
         super().__init__(self.fields,
                          p_values=p_values,
                          t_bin_width=t_bin_width,
@@ -292,6 +288,9 @@ class SNEWSSignificanceTierMessage(SNEWSMessage):
     def is_valid(self):
         """Check that parameter values are valid for this tier."""
         if not self.is_test:
+            # Type check for proper types.
+            if np.isscalar(self.message_data['p_values']):
+                raise RuntimeError(f'{self.__class__.__name__} p_values must be a list.')
             for pv in self.message_data['p_values']:
                 if isinstance(pv, str):
                     pv = float(pv)
@@ -302,6 +301,8 @@ class SNEWSSignificanceTierMessage(SNEWSMessage):
                     raise ValueError(f'{self.__class__.__name__} t_bin_width must be a float.')
             elif not isinstance(self.message_data['t_bin_width'], float):
                 raise ValueError(f'{self.__class__.__name__} t_bin_width must be a float.')
+
+
         return True
 
 

--- a/snews_pt/messages.py
+++ b/snews_pt/messages.py
@@ -328,6 +328,13 @@ class SNEWSTimingTierMessage(SNEWSMessage):
                 duration = (timeobj - datetime.utcnow()).total_seconds()
                 if (duration <= -172800.0) or (duration > 0.0):
                     raise ValueError(f'{self.__class__.__name__} neutrino_time must be within 48 hours of now.')
+
+                # p_val must be a float between 0 and 1
+                pv = self.message_data['p_val']
+                if isinstance(pv, str):
+                    pv = float(pv)
+                if not (0.0 <= pv <= 1.0):
+                    raise ValueError(f'{self.__class__.__name__} p_value of the detection must be between 0 and 1.')
         return True
 
 

--- a/snews_pt/snews_sub.py
+++ b/snews_pt/snews_sub.py
@@ -122,7 +122,7 @@ class Subscriber:
             click.secho('Done', fg='green')
 
 
-    def subscribe_and_redirect_alert(self, outputfolder=None, auth=True):
+    def subscribe_and_redirect_alert(self, outputfolder=None, auth=True, _display=True, _return='file'):
         """ subscribe generator
         """
         outputfolder = outputfolder or self.default_output
@@ -139,8 +139,12 @@ class Subscriber:
                     message = message.content
                     # Save and display
                     file = save_message(message, outputfolder, return_file=True)
-                    snews_pt_utils.display_gif()
-                    display(message)
-                    yield file
+                    if _display:
+                        snews_pt_utils.display_gif()
+                        display(message)
+                    if _return == 'message':
+                        yield message
+                    else:
+                        yield file
         except KeyboardInterrupt:
             click.secho('Done', fg='green')

--- a/snews_pt/test/test_coincidence_tier.py
+++ b/snews_pt/test/test_coincidence_tier.py
@@ -16,8 +16,11 @@ def test_coincidence_expected():
                                              'machine_time': '2012-06-09T15:30:00.000501',
                                              'schema_version': '1.3.0',
                                              'neutrino_time': '2012-06-09T15:31:08.891011',
+                                             'is_test': True,
                                              'p_val': None}
-    assert coin.messages[0].meta == {'is_test': True, 'firedrill_mode': False}
+
+    # firedrill_mode is an argument of coinc.send_messages(), so it becomes meta here
+    assert coin.messages[0].meta == {'firedrill_mode': False}
 
     # check if valid snews format
     assert coin.messages[0].is_valid() is True, "Message is not valid"

--- a/snews_pt/test/test_coincidence_tier.py
+++ b/snews_pt/test/test_coincidence_tier.py
@@ -14,7 +14,7 @@ def test_coincidence_expected():
     assert coin.messages[0].message_data == {'_id': 'KamLAND_CoincidenceTier_2012-06-09T15:30:00.000501',
                                              'detector_name': 'KamLAND',
                                              'machine_time': '2012-06-09T15:30:00.000501',
-                                             'schema_version': '1.3.0',
+                                             'schema_version': '1.3.1',
                                              'neutrino_time': '2012-06-09T15:31:08.891011',
                                              'is_test': True,
                                              'p_val': None}

--- a/snews_pt/test/test_heartbeat.py
+++ b/snews_pt/test/test_heartbeat.py
@@ -15,8 +15,11 @@ def test_heartbeat_expected():
                                            'schema_version': '1.3.0',
                                            'detector_name': 'XENONnT',
                                            'machine_time': '2012-06-09T15:30:00.000501',
-                                           'detector_status': 'ON'}
-    assert hb.messages[0].meta == {'is_test': True, 'firedrill_mode': False}
+                                           'detector_status': 'ON',
+                                           'is_test': True}
+
+    # firedrill_mode is an argument of hb.send_messages(), so it becomes meta here
+    assert hb.messages[0].meta == {'firedrill_mode': False}
 
     # # check if valid snews format
     assert hb.messages[0].is_valid() is True, "Message is not valid"

--- a/snews_pt/test/test_heartbeat.py
+++ b/snews_pt/test/test_heartbeat.py
@@ -12,7 +12,7 @@ def test_heartbeat_expected():
     assert len(hb.messages) == 1, f"Expected 1 Heartbeat Message got {len(hb.messages)}!"
 
     assert hb.messages[0].message_data == {'_id': 'XENONnT_Heartbeat_2012-06-09T15:30:00.000501',
-                                           'schema_version': '1.3.0',
+                                           'schema_version': '1.3.1',
                                            'detector_name': 'XENONnT',
                                            'machine_time': '2012-06-09T15:30:00.000501',
                                            'detector_status': 'ON',

--- a/snews_pt/test/test_retraction.py
+++ b/snews_pt/test/test_retraction.py
@@ -23,7 +23,7 @@ def test_retraction():
                                              is_test=True, firedrill_mode=False)
     assert retraction_message.selected_tiers == ["SNEWSRetractionMessage"]
     assert retraction_message.messages[0].message_data == {'_id': 'KamLAND_Retraction_2012-06-09T15:30:00.000501',
-                                                           'schema_version': '1.3.0',
+                                                           'schema_version': '1.3.1',
                                                            'detector_name': 'KamLAND',
                                                            'machine_time': '2012-06-09T15:30:00.000501',
                                                            'retract_latest': 1,

--- a/snews_pt/test/test_retraction.py
+++ b/snews_pt/test/test_retraction.py
@@ -27,8 +27,11 @@ def test_retraction():
                                                            'detector_name': 'KamLAND',
                                                            'machine_time': '2012-06-09T15:30:00.000501',
                                                            'retract_latest': 1,
-                                                           'retraction_reason': None}, "created message data is wrong"
-    assert retraction_message.messages[0].meta == {'is_test': True, 'firedrill_mode': False}, "created meta is wrong"
+                                                           'retraction_reason': None,
+                                                           'is_test': True}, "created message data is wrong"
+
+    # firedrill_mode is an argument of retraction_message.send_messages(), so it becomes meta here
+    assert retraction_message.messages[0].meta == {'firedrill_mode': False}, "created meta is wrong"
     assert retraction_message.messages[0].is_valid() is True, "Invalid retraction message created"
 
     try:

--- a/snews_pt/test/test_significance_tier.py
+++ b/snews_pt/test/test_significance_tier.py
@@ -21,11 +21,11 @@ def test_significance_expected():
                                              'detector_name': 'DS-20K',
                                              'machine_time': '2012-06-09T15:30:00.000501',
                                              'neutrino_time': '2012-06-09T15:31:08.109876',
-                                             'p_val': None}
+                                             'p_val': None,
+                                             'is_test': True}
 
     assert sign.messages[0].meta == {'p_values': [0.4, 0.5],
                                      't_bin_width': 0.8,
-                                     'is_test': True,
                                      'neutrino_times': ['2012-06-09T15:31:08.109876',
                                                         '2012-06-09T15:33:07.891098'],
                                      'firedrill_mode': False}
@@ -35,13 +35,13 @@ def test_significance_expected():
                                              'detector_name': 'DS-20K',
                                              'machine_time': '2012-06-09T15:30:00.000501',
                                              'p_values': [0.4, 0.5],
-                                             't_bin_width': 0.8}
+                                             't_bin_width': 0.8,
+                                             'is_test': True}
 
     assert sign.messages[1].meta == {'neutrino_time': '2012-06-09T15:31:08.109876',
-                                     'is_test': True,
                                      'neutrino_times': ['2012-06-09T15:31:08.109876',
                                                         '2012-06-09T15:33:07.891098'],
-                                     'firedrill_mode': False}
+                                     'firedrill_mode': False,}
 
     assert sign.messages[0].is_valid() is True, "invalid coincidence tier message in 'test_significance_tier'"
     assert sign.messages[1].is_valid() is True, "invalid significance tier message in 'test_significance_tier'"

--- a/snews_pt/test/test_significance_tier.py
+++ b/snews_pt/test/test_significance_tier.py
@@ -17,7 +17,7 @@ def test_significance_expected():
     # Check that message has expected structure.
     assert sign.selected_tiers == ['SNEWSCoincidenceTierMessage', 'SNEWSSignificanceTierMessage']
     assert sign.messages[0].message_data == {'_id': 'DS-20K_CoincidenceTier_2012-06-09T15:30:00.000501',
-                                             'schema_version': '1.3.0',
+                                             'schema_version': '1.3.1',
                                              'detector_name': 'DS-20K',
                                              'machine_time': '2012-06-09T15:30:00.000501',
                                              'neutrino_time': '2012-06-09T15:31:08.109876',
@@ -31,7 +31,7 @@ def test_significance_expected():
                                      'firedrill_mode': False}
 
     assert sign.messages[1].message_data == {'_id': 'DS-20K_SignificanceTier_2012-06-09T15:30:00.000501',
-                                             'schema_version': '1.3.0',
+                                             'schema_version': '1.3.1',
                                              'detector_name': 'DS-20K',
                                              'machine_time': '2012-06-09T15:30:00.000501',
                                              'p_values': [0.4, 0.5],

--- a/snews_pt/test/test_timing_tier.py
+++ b/snews_pt/test/test_timing_tier.py
@@ -16,9 +16,10 @@ def test_timing_expected():
                                              'detector_name': 'XENONnT',
                                              'machine_time': '2012-06-09T15:30:00.009876',
                                              'p_val': None,
+                                             'is_test': True,
                                              'timing_series': ['2012-06-09T15:31:08.109876',
                                                                '2012-06-09T15:33:07.891011']}
-    assert tims.messages[0].meta == {'is_test': True, 'firedrill_mode': False}
+    assert tims.messages[0].meta == { 'firedrill_mode': False}
 
     assert tims.messages[0].is_valid() is True, "There are invalid messages"
 

--- a/snews_pt/test/test_timing_tier.py
+++ b/snews_pt/test/test_timing_tier.py
@@ -12,7 +12,7 @@ def test_timing_expected():
     # # Check that message has expected structure.
     assert tims.selected_tiers == ['SNEWSTimingTierMessage']
     assert tims.messages[0].message_data == {'_id': 'XENONnT_TimingTier_2012-06-09T15:30:00.009876',
-                                             'schema_version': '1.3.0',
+                                             'schema_version': '1.3.1',
                                              'detector_name': 'XENONnT',
                                              'machine_time': '2012-06-09T15:30:00.009876',
                                              'p_val': None,


### PR DESCRIPTION
In the past we got rid of the `meta` field where we used to group all unknown key-value pairs. Instead we were now adding them as new key-value pairs to the dictionary. 

However, with the new SQL backed, this seemed more complicated to track. So, I rolled back to the original idea.

If the user builds a message that contains some key-value pairs "that do not belong to ANY of the created tiers" they are shipped under the `"meta"` key in the message. These meta keys are NOT displayed in the alert messages but they are there for long-term storage and additional investigation, e.g. any comment the user might have, or any additional data that they might provide for triangulation etc. Coincidence System (snews cs) does not try to investigate the data send under the meta.

Along with this addition, I also

 - fix the detector name setting issue
 - made `is_test` an accepted argument for each tier, defaulted it to False when nothing is passed
 - updated the notebooks