### PR TITLE
Stupid iso fix

### DIFF
--- a/snews_pt/snews_format_checker.py
+++ b/snews_pt/snews_format_checker.py
@@ -10,6 +10,8 @@ from .core.logging import getLogger, log_file
 import warnings
 import click
 import numpy as np
+import re
+
 log_default = getLogger(__name__)
 
 def is_valid_iso_utc(text):


### PR DESCRIPTION

We still keep the "snews+format_checker.py" to be used on the server side when double-validating the messages. 

For now, this PR addresses the issue with ISO formats;

Valid <br>
`"2023-06-9999999:45:100000"`

Should still be accepted with proper rounding <br>
`""2023-06-9999999:45:10"` <br>
`"2023-06-9999999:45:1000001234"` <br>