### PR TITLE
Readthedocx fix 202402

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,14 +1,22 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
+# Required
 version: 2
 
+# Set the OS, Python version and other tools you might need
 build:
-  os: "ubuntu-20.04"
-  tools:
-    python: "3.9"
+    os: ubuntu-22.04
+    tools:
+        python: "3.12"
 
+# Build documentation in the "doc/" directory with Sphinx
 sphinx:
-  configuration: docs/conf.py
+    configuration: doc/conf.py
 
+# Python requirements required to build documentation.
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
-  install:
-    - requirements: doc/requirements.txt
+    install:
+        - requirements: doc/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,4 +11,4 @@ sphinx:
 
 python:
   install:
-    - requirements: requirements.txt
+    - requirements: doc/requirements.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,7 +75,7 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,28 @@
+# Required packages
+#
+click~=8.1
+hop-client~=0.8.0
+inquirer~=2.8
+ipython~=8.7
+numpy~=1.26
+python-dotenv~=0.19
+setuptools~=69.0
+wheel~=0.42
+#
+# Development packages
+#
+virtualenv~=20.13
+pytest~=8.0
+pytest-console-scripts~=1.4
+pytest-cov~=4.1
+pytest-mongodb~=2.4
+pytest-runner~=6.0
+#
+# Documentation packages 
+#
+autoapi~=2.0.1
+myst-parser~=2.0
+sphinx~=7.2
+sphinx-autoapi~=3.0
+sphinx_rtd_theme~=2.0
+sphinxcontrib-programoutput~=0.17


### PR DESCRIPTION
Partially addresses the dependency updates outlined in #91. This specifically updates a new `doc/requirements.txt` file with some cleanup of `doc/conf.py` to reduce warnings.