### PR TITLE
Fix typo on setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ extras_require = {
     'dev': [
         'pytest~=8.0',
         'pytest-console-scripts~=1.4',
-        'pytest-cov~-4.1',
+        'pytest-cov~=4.1',
         'pytest-mongodb~=2.4',
         'pytest-runner~=6.0',
         'virtualenv~=20.13',


### PR DESCRIPTION
Development installation failing because of typo on `extra_require`.