### PR TITLE
update actions

### DIFF
--- a/.github/workflows/mac12-py311-312.yml
+++ b/.github/workflows/mac12-py311-312.yml
@@ -2,7 +2,7 @@ name: Mac 12 Python 3.11-12
 
 on:
   push:
-    branches: [ smolsky/testing ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/mac13-py311-312.yml
+++ b/.github/workflows/mac13-py311-312.yml
@@ -2,7 +2,7 @@ name: Mac 13 Python 3.11-12
 
 on:
   push:
-    branches: [ smolsky/testing ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/mac14-py311-312.yml
+++ b/.github/workflows/mac14-py311-312.yml
@@ -3,7 +3,7 @@ name: Mac 14
 
 on:
   push:
-    branches: [ smolsky/testing ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/ubuntu22-py311-312.yml
+++ b/.github/workflows/ubuntu22-py311-312.yml
@@ -3,7 +3,6 @@ name: Ubuntu 22.04 Python 3.11-12
 on:
   push:
     branches:
-      - smolsky/testing
       - main
 
   pull_request:
@@ -41,7 +40,7 @@ jobs:
 
     - name: Install hop-client
       run: |
-        pip install install setuptools wheel
+        pip install setuptools wheel
         wget https://files.pythonhosted.org/packages/64/d1/108cea042128c7ea7790e15e12e3e5ed595bfcf4b051c34fe1064924beba/hop-client-0.9.0.tar.gz
         tar -xzf hop-client-0.9.0.tar.gz
         cd hop-client-0.9.0


### PR DESCRIPTION
For some reason github actions started to fail. <br>

It seems like [this line](https://github.com/SNEWS2/SNEWS_Publishing_Tools/blob/519bd38d3a48e4ac5e2763ceac099245a9a91fc2/.github/workflows/ubuntu22-py311-312.yml#L44), has a duplicate "install" thus it tries to install a package called "install" and crashes at that point. While I am not sure why this was not a failing before, this patch should fix it. <br>

Similarly, the Mac actions were set to run on smolsky/testing branch which no longer exists. I pointed that to main branch as well. 