### PR TITLE
Update run-scenarios to handle snews-data-formats

### DIFF
--- a/snews_pt/auxiliary/try_scenarios.py
+++ b/snews_pt/auxiliary/try_scenarios.py
@@ -1,8 +1,10 @@
 
 import json, click, time, sys
 from os import path as osp
-from snews_pt.messages import SNEWSMessageBuilder, Publisher
+from snews_pt.messages import Publisher
 from snews_pt.remote_commands import reset_cache
+from snews.data.mock import coincidence_scenarios
+from snews.models.messages import CoincidenceTierMessage
 
 fd_mode = True if sys.argv[1].lower() == "true" else False
 is_test = True if sys.argv[2].lower() == "true" else False
@@ -12,17 +14,19 @@ if not is_test:
                 "We are running the scenarios in test mode", fg='red', bold=True)
     is_test = True
 
-with open(osp.join(osp.dirname(__file__), "scenarios.json")) as json_file:
-    data = json.load(json_file)
+scenarios_labels = [d['label'] for d in coincidence_scenarios]
 
 try:
     import inquirer
     questions = [
     inquirer.Checkbox('scenarios',
-                    message=click.style(" Which scenario(s) would you like to run next?", bg='yellow', bold=True),
-                    choices=list(data.keys())+list(["finish & exit", "restart cache"]),
-                )
-    ]
+                    message=click.style(
+                        " Which scenario(s) would you like to run next?", 
+                        bg='yellow', bold=True),
+                    choices=scenarios_labels + ["finish & exit", 
+                                                "restart cache"],
+                    )
+                ]
 
     while True:
         try:
@@ -36,15 +40,30 @@ try:
                     print('> Cache cleaned\n')
                 else:
                     click.secho(f"\n>>> Testing {scenario}", fg='yellow', bold=True)
-                    messages = data[scenario]
-                    for msg in messages: # send one by one and sleep in between
-                        print(msg, "\n\n")
-                        SNEWSMessageBuilder(**msg).send_messages(firedrill_mode=fd_mode)
-                        time.sleep(1)
-                        # clear cache after each scenario
+                    
+                    # Find the dict for the scenario in coincidence_scenarios
+                    scenario_dict = [d for d in coincidence_scenarios if d['label'] == scenario][0]
+                    scenario_events = scenario_dict['events']
+
+                    with Publisher(firedrill_mode=fd_mode, verbose=False) as pub:
+
+                        for evt in scenario_events: # send one by one and sleep in between
+                            print(evt, "\n\n")
+                            msg = CoincidenceTierMessage(detector_name = evt['detector_name'], 
+                                neutrino_time_utc = evt['neutrino_time'],
+                                is_test = True) # allow future timestamps
+                            
+                            pub.add_message(msg)
+                            time.sleep(1)
+
+                        pub.send()
+                        print(f'> {len(scenario_events)} messages sent.')
+
+                    # clear cache after each scenario
                     with Publisher(firedrill_mode=fd_mode, verbose=False) as pub:
                         reset_cache(firedrill=fd_mode, is_test=is_test)
                         print('> Cache cleaned\n')
+                        
         except KeyboardInterrupt:
             break
 except Exception as e:

--- a/snews_pt/auxiliary/try_scenarios.py
+++ b/snews_pt/auxiliary/try_scenarios.py
@@ -1,6 +1,6 @@
 
 import json, click, time, sys
-from os import path as osp
+import os
 from snews_pt.messages import Publisher
 from snews_pt.remote_commands import reset_cache
 from snews.data.mock import coincidence_scenarios
@@ -8,6 +8,11 @@ from snews.models.messages import CoincidenceTierMessage
 
 fd_mode = True if sys.argv[1].lower() == "true" else False
 is_test = True if sys.argv[2].lower() == "true" else False
+
+if fd_mode:
+    topic = os.getenv("FIREDRILL_OBSERVATION_TOPIC")
+else:
+    topic = os.getenv("OBSERVATION_TOPIC")
 
 if not is_test:
     click.secho("This script is only for testing purposes, and uses past neutrino times.\n"
@@ -45,7 +50,7 @@ try:
                     scenario_dict = [d for d in coincidence_scenarios if d['label'] == scenario][0]
                     scenario_events = scenario_dict['events']
 
-                    with Publisher(firedrill_mode=fd_mode, verbose=False) as pub:
+                    with Publisher(kafka_topic = topic) as pub:
 
                         for evt in scenario_events: # send one by one and sleep in between
                             print(evt, "\n\n")
@@ -60,7 +65,7 @@ try:
                         print(f'> {len(scenario_events)} messages sent.')
 
                     # clear cache after each scenario
-                    with Publisher(firedrill_mode=fd_mode, verbose=False) as pub:
+                    with Publisher(kafka_topic = topic) as pub:
                         reset_cache(firedrill=fd_mode, is_test=is_test)
                         print('> Cache cleaned\n')
                         


### PR DESCRIPTION
The `run-scenarios` function is for not working for now by using the deprecated `SNEWSMessageBuilder` class. This PR updates the try_scenarios.py file to make it work in the new message-handling system.