### PR TITLE
Remove detector name requirement in test-connection

### DIFF
--- a/snews_pt/__main__.py
+++ b/snews_pt/__main__.py
@@ -263,7 +263,6 @@ def test_connection(ctx, firedrill, start_at, patience):
     from .remote_commands import test_connection
 
     test_connection(
-        detector_name=ctx.obj["DETECTOR_NAME"],
         firedrill=firedrill,
         start_at=start_at,
         patience=patience,

--- a/snews_pt/remote_commands.py
+++ b/snews_pt/remote_commands.py
@@ -14,7 +14,7 @@ from hop.io import StartPosition
 from hop.models import JSONBlob
 
 
-def test_connection(detector_name=None, firedrill=True, start_at="LATEST", patience=8):
+def test_connection(firedrill=True, start_at="LATEST", patience=8):
     """ test the server connection
         It should prompt your whether the
         coincidence script is running in the server
@@ -31,12 +31,12 @@ def test_connection(detector_name=None, firedrill=True, start_at="LATEST", patie
             None
 
     """
-    detector_name = detector_name or os.getenv("DETECTOR_NAME")
+
     default_connection_topic = "kafka://kafka.scimma.org/snews.connection-testing"
     connection_broker = os.getenv("CONNECTION_TEST_TOPIC", default_connection_topic)
     stamp_time = datetime.now(UTC).isoformat()
     message = {'_id': '0_test-connection',
-               'detector_name': detector_name,
+
                'time': stamp_time,
                'status': 'sending',
                'meta':{}}
@@ -64,9 +64,8 @@ def test_connection(detector_name=None, firedrill=True, start_at="LATEST", patie
         for read in ss:
             read = read.content
             if read == message_expected:
-                read_name = click.style(read['detector_name'], fg='green', bold=True)
                 read_time = click.style(read['time'], fg='green', bold=True)
-                click.echo(f"You ({read_name}) have a connection to the server at {read_time}")
+                click.echo(f"You have a connection to the server at {read_time}")
                 confirmed=True
                 break
             else: # if there is no else: continue statement, it does not work


### PR DESCRIPTION
Since the connection is user-based, there's no need to have the detector name set a priori. 
When running, it will still complain that it is not set.