### PR TITLE
Reduce minimum Python to 3.9.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         # Test all supported Python versions under Ubuntu
         os: [ubuntu-latest, macos-latest]
-        python-version: ['3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     # The type of runner that the job will run on.
     runs-on: ${{ matrix.os }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 license = {text = "BSD-3-Clause"}
 readme = "README.md"
-requires-python = ">=3.11,<3.13"
+requires-python = ">=3.9,<3.13"
 classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",

--- a/snews_pt/messages.py
+++ b/snews_pt/messages.py
@@ -1,6 +1,14 @@
 import json
 import pickle
-from datetime import UTC, datetime
+from datetime import datetime
+
+# Import for Python <3.11.
+try:
+    from datetime import UTC
+except ImportError as e:
+    from datetime import timezone
+    UTC = timezone.utc
+
 from typing import Union
 
 from hop import Stream

--- a/snews_pt/remote_commands.py
+++ b/snews_pt/remote_commands.py
@@ -7,7 +7,14 @@ Melih Kara, kara@kit.edu
 
 import os
 import time
-from datetime import UTC, datetime
+from datetime import datetime
+
+# Import for Python <3.11.
+try:
+    from datetime import UTC
+except ImportError as e:
+    from datetime import timezone
+    UTC = timezone.utc
 
 import click
 from hop import Stream


### PR DESCRIPTION
PR to address #146, which was requested after the fire drills on May 28.